### PR TITLE
로그인 기능 구현

### DIFF
--- a/src/components/login-signup/form/login/index.tsx
+++ b/src/components/login-signup/form/login/index.tsx
@@ -1,5 +1,8 @@
+import { useRouter } from 'next/router'
+import { useState } from 'react'
 import { useForm, SubmitHandler } from 'react-hook-form'
 
+import AXIOS from '@/lib/axios'
 import BasicButton from '@/src/components/common/button/basic'
 import Input from '@/src/components/common/input'
 import { InputFormValues } from '@/src/types/input'
@@ -7,6 +10,9 @@ import { InputFormValues } from '@/src/types/input'
 import S from '../Form.module.scss'
 
 const LogInForm = () => {
+  const router = useRouter()
+  const [loginError, setLoginError] = useState('')
+
   const {
     register,
     handleSubmit,
@@ -15,11 +21,23 @@ const LogInForm = () => {
   } = useForm<InputFormValues>({ mode: 'onBlur' })
 
   const onSubmit: SubmitHandler<InputFormValues> = (data) => {
-    console.log(data)
+    if (data.email === '' || data.password === '') return
+
+    AXIOS.post('/auth/login', {
+      email: data.email,
+      password: data.password,
+    })
+      .then((res) => {
+        localStorage.setItem('accessToken', res.data.accessToken)
+        router.push('/mydashboard')
+      })
+      .catch((err) => {
+        setLoginError(err.response.data.message)
+      })
   }
 
   return (
-    <form className={S.container}>
+    <form className={S.container} onSubmit={handleSubmit(onSubmit)}>
       <label className={S.label}>이메일</label>
       <Input
         inputType="email"
@@ -34,7 +52,13 @@ const LogInForm = () => {
         error={errors.password}
         register={register}
       />
-      <BasicButton size="large" isDisabled={true}>
+      <span className={S.errorText}>* {loginError}</span>
+      <BasicButton
+        size="large"
+        isDisabled={
+          watch('email') === '' || watch('password') === '' ? true : false
+        }
+      >
         <span className={S.buttonText}>로그인</span>
       </BasicButton>
     </form>

--- a/src/components/login-signup/form/login/index.tsx
+++ b/src/components/login-signup/form/login/index.tsx
@@ -1,9 +1,9 @@
 import { useForm, SubmitHandler } from 'react-hook-form'
 
+import BasicButton from '@/src/components/common/button/basic'
 import Input from '@/src/components/common/input'
 import { InputFormValues } from '@/src/types/input'
 
-import Button from '../../button'
 import S from '../Form.module.scss'
 
 const LogInForm = () => {
@@ -34,9 +34,9 @@ const LogInForm = () => {
         error={errors.password}
         register={register}
       />
-      <Button>
+      <BasicButton size="large" isDisabled={true}>
         <span className={S.buttonText}>로그인</span>
-      </Button>
+      </BasicButton>
     </form>
   )
 }

--- a/src/components/login-signup/form/login/index.tsx
+++ b/src/components/login-signup/form/login/index.tsx
@@ -1,14 +1,39 @@
+import { useForm, SubmitHandler } from 'react-hook-form'
+
+import Input from '@/src/components/common/input'
+import { InputFormValues } from '@/src/types/input'
+
 import Button from '../../button'
-import LogInInput from '../../input/login'
 import S from '../Form.module.scss'
 
 const LogInForm = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    watch,
+  } = useForm<InputFormValues>({ mode: 'onBlur' })
+
+  const onSubmit: SubmitHandler<InputFormValues> = (data) => {
+    console.log(data)
+  }
+
   return (
     <form className={S.container}>
       <label className={S.label}>이메일</label>
-      <LogInInput inputType="email" error={false} />
+      <Input
+        inputType="email"
+        placeholder="이메일을 입력해주세요"
+        error={errors.email}
+        register={register}
+      />
       <label className={S.label}>비밀번호</label>
-      <LogInInput inputType="password" error={false} />
+      <Input
+        inputType="password"
+        placeholder="비밀번호를 입력해 주세요"
+        error={errors.password}
+        register={register}
+      />
       <Button>
         <span className={S.buttonText}>로그인</span>
       </Button>


### PR DESCRIPTION
## 🚀 주요 변경 사항

### 관련 이슈
#7 

### access token 저장 위치
- refresh token이 발급되지 않는 관계로, 메모리에 저장해둔 후 refresh token을 사용해 재인증 하는 방식은 사용 불가능
- 따라서 우선은 local storage로 관리하였으며, 추후 더 안전한 방법을 찾게 되면 교체 예정

### 기획과 API 명세서의 불일치 문제

#### 기획
- 비밀번호가 틀릴 경우 “비밀번호가 일치하지 않습니다.” 경고 창을 보여줍니다.

#### API 명세서
- 로그인 실패 시, 이메일 형식에 대한 오류와 존재하지 않는 유저에 대한 오류만 검증할 뿐 비밀번호 일치 여부에 대한 검증은 진행되지 않음

#### 결론
- API 명세서를 따름


## 🖼️ 스크린샷
<img width="400" alt="image" src="https://github.com/WhatToDo6/WhatToDo/assets/77491430/e5d8dd32-07c8-4c8d-832f-0d13ed0b48cd">

## 📝 기타 논의 사항
- 안전한 access token 관리 방법 추천 받아요 .. ! 🔥 