### PR TITLE
Input text 공통 컴포넌트 세분화

### DIFF
--- a/src/components/common/input/index.tsx
+++ b/src/components/common/input/index.tsx
@@ -32,8 +32,21 @@ const Input = ({
         password={password || ''}
       />
     ),
-    text: (
-      <InputText placeholder={placeholder} error={error} register={register} />
+    nickname: (
+      <InputText
+        placeholder={placeholder}
+        error={error}
+        register={register}
+        textType="nickname"
+      />
+    ),
+    title: (
+      <InputText
+        placeholder={placeholder}
+        error={error}
+        register={register}
+        textType="title"
+      />
     ),
     date: <input type="date" />, // TODO: date input
     tag: <input type="tag" />, // TODO: tag input

--- a/src/components/common/input/text/index.tsx
+++ b/src/components/common/input/text/index.tsx
@@ -2,15 +2,35 @@ import { InputProps } from '@/src/types/input'
 
 import S from './Text.module.scss'
 
-const InputText = ({ placeholder, error, register }: InputProps) => {
+interface InputTextProps extends InputProps {
+  textType: 'nickname' | 'title' // 다른 input이 필요하면 추가
+}
+
+const InputText = ({
+  placeholder,
+  error,
+  register,
+  textType,
+}: InputTextProps) => {
+  const VALIDATION_MAP = {
+    nickname: {
+      required: '닉네임을 입력해주세요.',
+      validate: (value: string) => {
+        return value.length < 10 || '10자 이하로 작성해주세요.'
+      },
+    },
+    title: {
+      required: '제목을 입력해주세요.',
+      // TODO: 제목 유효성 검사 로직
+    },
+  }
+
   return (
     <input
       className={`${S.container} ${error && S.error}`}
       type="text"
       placeholder={placeholder}
-      {...register('text', {
-        required: '닉네임을 입력해주세요.',
-      })}
+      {...register(textType, VALIDATION_MAP[textType])}
     />
   )
 }

--- a/src/components/login-signup/form/login/index.tsx
+++ b/src/components/login-signup/form/login/index.tsx
@@ -1,5 +1,8 @@
+import { useRouter } from 'next/router'
+import { useState } from 'react'
 import { useForm, SubmitHandler } from 'react-hook-form'
 
+import AXIOS from '@/lib/axios'
 import BasicButton from '@/src/components/common/button/basic'
 import Input from '@/src/components/common/input'
 import { InputFormValues } from '@/src/types/input'
@@ -7,6 +10,9 @@ import { InputFormValues } from '@/src/types/input'
 import S from '../Form.module.scss'
 
 const LogInForm = () => {
+  const router = useRouter()
+  const [loginError, setLoginError] = useState('')
+
   const {
     register,
     handleSubmit,
@@ -15,11 +21,23 @@ const LogInForm = () => {
   } = useForm<InputFormValues>({ mode: 'onBlur' })
 
   const onSubmit: SubmitHandler<InputFormValues> = (data) => {
-    console.log(data)
+    if (data.email === '' || data.password === '') return
+
+    AXIOS.post('/auth/login', {
+      email: data.email,
+      password: data.password,
+    })
+      .then((res) => {
+        localStorage.setItem('accessToken', res.data.accessToken)
+        router.push('/mydashboard')
+      })
+      .catch((err) => {
+        setLoginError(err.response.data.message)
+      })
   }
 
   return (
-    <form className={S.container}>
+    <form className={S.container} onSubmit={handleSubmit(onSubmit)}>
       <label className={S.label}>이메일</label>
       <Input
         inputType="email"
@@ -34,7 +52,13 @@ const LogInForm = () => {
         error={errors.password}
         register={register}
       />
-      <BasicButton size="large" isDisabled={true}>
+      <span className={S.errorText}>* {loginError}</span>
+      <BasicButton
+        size="large"
+        isDisabled={
+          watch('email') === '' || watch('password') === '' ? true : false
+        }
+      >
         <span className={S.buttonText}>로그인</span>
       </BasicButton>
     </form>

--- a/src/components/login-signup/form/login/index.tsx
+++ b/src/components/login-signup/form/login/index.tsx
@@ -1,9 +1,9 @@
 import { useForm, SubmitHandler } from 'react-hook-form'
 
+import BasicButton from '@/src/components/common/button/basic'
 import Input from '@/src/components/common/input'
 import { InputFormValues } from '@/src/types/input'
 
-import Button from '../../button'
 import S from '../Form.module.scss'
 
 const LogInForm = () => {
@@ -34,9 +34,9 @@ const LogInForm = () => {
         error={errors.password}
         register={register}
       />
-      <Button>
+      <BasicButton size="large" isDisabled={true}>
         <span className={S.buttonText}>로그인</span>
-      </Button>
+      </BasicButton>
     </form>
   )
 }

--- a/src/components/login-signup/form/login/index.tsx
+++ b/src/components/login-signup/form/login/index.tsx
@@ -1,14 +1,39 @@
+import { useForm, SubmitHandler } from 'react-hook-form'
+
+import Input from '@/src/components/common/input'
+import { InputFormValues } from '@/src/types/input'
+
 import Button from '../../button'
-import LogInInput from '../../input/login'
 import S from '../Form.module.scss'
 
 const LogInForm = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    watch,
+  } = useForm<InputFormValues>({ mode: 'onBlur' })
+
+  const onSubmit: SubmitHandler<InputFormValues> = (data) => {
+    console.log(data)
+  }
+
   return (
     <form className={S.container}>
       <label className={S.label}>이메일</label>
-      <LogInInput inputType="email" error={false} />
+      <Input
+        inputType="email"
+        placeholder="이메일을 입력해주세요"
+        error={errors.email}
+        register={register}
+      />
       <label className={S.label}>비밀번호</label>
-      <LogInInput inputType="password" error={false} />
+      <Input
+        inputType="password"
+        placeholder="비밀번호를 입력해 주세요"
+        error={errors.password}
+        register={register}
+      />
       <Button>
         <span className={S.buttonText}>로그인</span>
       </Button>

--- a/src/components/login-signup/form/signup/index.tsx
+++ b/src/components/login-signup/form/signup/index.tsx
@@ -29,9 +29,9 @@ const SignUpForm = () => {
       />
       <label className={S.label}>닉네임</label>
       <Input
-        inputType="text"
+        inputType="nickname"
         placeholder="닉네임을 입력해 주세요"
-        error={errors.text}
+        error={errors.nickname}
         register={register}
       />
       <label className={S.label}>비밀번호</label>

--- a/src/types/input.ts
+++ b/src/types/input.ts
@@ -5,7 +5,8 @@ export interface InputInterface {
     | 'email'
     | 'password'
     | 'passwordCheck'
-    | 'text'
+    | 'nickname'
+    | 'title'
     | 'date'
     | 'tag'
     | 'textarea'
@@ -18,7 +19,8 @@ export interface InputFormValues {
   email: string
   password: string
   passwordCheck: string
-  text: string
+  nickname: string
+  title: string
   date: string
   tag: string
   textarea: string


### PR DESCRIPTION
## 🚀 주요 변경 사항

### 관련 이슈 #27 

```tsx
interface InputTextProps extends InputProps {
  textType: 'nickname' | 'title' // 다른 input이 필요하면 추가
}

const InputText = ({
  placeholder,
  error,
  register,
  textType,
}: InputTextProps) => {
  const VALIDATION_MAP = {
    nickname: {
      required: '닉네임을 입력해주세요.',
      validate: (value: string) => {
        return value.length < 10 || '10자 이하로 작성해주세요.'
      },
    },
    title: {
      required: '제목을 입력해주세요.',
      // TODO: 제목 유효성 검사 로직
    },
  }

  return (
    <input
      className={`${S.container} ${error && S.error}`}
      type="text"
      placeholder={placeholder}
      {...register(textType, VALIDATION_MAP[textType])}
    />
  )
}
```

## 🖼️ 스크린샷
<img width="500" alt="image" src="https://github.com/WhatToDo6/WhatToDo/assets/77491430/6eef488f-a7d5-4ef7-b623-adde50a8ae4b">


## 📝 기타 논의 사항
필요한 validation 로직이 생기거나, 또다른 input text 컴포넌트가 필요할 때 추가해서 사용하면 될 것 같습니다 :)