### PR TITLE
이미지 업로드 input 분리

### DIFF
--- a/src/components/common/input/image-upload/ImageUpload.module.scss
+++ b/src/components/common/input/image-upload/ImageUpload.module.scss
@@ -1,0 +1,47 @@
+@import '@/src/styles/global.scss';
+
+.container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 18.2rem;
+  height: 18.2rem;
+  background-color: #f5f5f5;
+  border-radius: 0.6rem;
+
+  @include mobile {
+    width: 10rem;
+    height: 10rem;
+  }
+}
+
+.small {
+  width: 7.6rem;
+  height: 7.6rem;
+
+  @include mobile {
+    width: 5.8rem;
+    height: 5.8rem;
+  }
+}
+
+.img {
+  @include mobile {
+    width: 2rem;
+    height: 2rem;
+  }
+}
+
+.smallImg {
+  width: 2.8rem;
+  height: 2.8rem;
+
+  @include mobile {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}
+
+.input {
+  display: none;
+}

--- a/src/components/common/input/image-upload/index.tsx
+++ b/src/components/common/input/image-upload/index.tsx
@@ -1,0 +1,43 @@
+import Image from 'next/image'
+import { ChangeEvent } from 'react'
+import { useForm } from 'react-hook-form'
+
+import ADD_IMG from '@/public/icons/add-img.svg'
+import { InputFormValues } from '@/src/types/input'
+
+import S from './ImageUpload.module.scss'
+
+interface InputImageUploadProps {
+  handleImageChange: (e: ChangeEvent<HTMLInputElement>) => void
+  isSmall?: boolean
+}
+
+const InputImageUpload = ({
+  handleImageChange,
+  isSmall = false,
+}: InputImageUploadProps) => {
+  const { register } = useForm<InputFormValues>()
+
+  return (
+    <div className={`${S.container} ${isSmall && S.small}`}>
+      <label htmlFor="profileImageUpload">
+        <Image
+          className={`${S.img} ${isSmall && S.smallImg}`}
+          src={ADD_IMG}
+          alt="Upload image icon"
+          width={30}
+          height={30}
+        />
+      </label>
+      <input
+        id="profileImageUpload"
+        type="file"
+        {...register('profileImageUrl')}
+        onChange={handleImageChange}
+        className={S.input}
+      />
+    </div>
+  )
+}
+
+export default InputImageUpload

--- a/src/components/mypage/profile-form/ProfileForm.module.scss
+++ b/src/components/mypage/profile-form/ProfileForm.module.scss
@@ -20,32 +20,6 @@
   }
 }
 
-.img-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 18.2rem;
-  height: 18.2rem;
-  background-color: #f5f5f5;
-  border-radius: 0.6rem;
-
-  @include mobile {
-    width: 10rem;
-    height: 10rem;
-  }
-}
-
-.img {
-  @include mobile {
-    width: 2rem;
-    height: 2rem;
-  }
-}
-
-.img-input {
-  display: none;
-}
-
 .text-container {
   display: flex;
   flex-direction: column;

--- a/src/components/mypage/profile-form/index.tsx
+++ b/src/components/mypage/profile-form/index.tsx
@@ -1,15 +1,14 @@
-import Image from 'next/image'
 import { useState, ChangeEvent } from 'react'
 import { useForm, SubmitHandler } from 'react-hook-form'
 
 import AXIOS from '@/lib/axios'
-import ADD_IMG from '@/public/icons/add-img.svg'
 import BorderButton from '@/src/components/common/button/border'
 import Input from '@/src/components/common/input'
 import { useUserData } from '@/src/hooks/useUserData'
 import { InputFormValues } from '@/src/types/input'
 
 import S from './ProfileForm.module.scss'
+import InputImageUpload from '../../common/input/image-upload'
 
 const ProfileForm = () => {
   const userData = useUserData()
@@ -72,18 +71,7 @@ const ProfileForm = () => {
   return (
     <form onSubmit={handleSubmit(onSubmit)} className={S.container}>
       <div className={S.content}>
-        <div className={S['img-container']}>
-          <label htmlFor="profileImageUpload" className={S.img}>
-            <Image src={ADD_IMG} alt="" width={30} height={30} />
-          </label>
-          <input
-            id="profileImageUpload"
-            type="file"
-            {...register('profileImageUrl')}
-            onChange={handleImageChange}
-            className={S['img-input']}
-          />
-        </div>
+        <InputImageUpload handleImageChange={handleImageChange} />
         <div className={S['text-container']}>
           <label className={S.title}>이메일</label>
           <input


### PR DESCRIPTION
## 🚀 주요 변경 사항

- 이미지 업로드 input을 InputImageUpload 컴포넌트로 분리했습니다. 
- 우선 계정관리랑 할 일 생성에 사용되는 기본 이미지 업로드에 대한 작업만 진행하였습니다. 
- 이미지 업로드 하면 미리보기로 보여줘야 하는 작업은 추후 진행할 예정입니다. 

## 🖼️ 스크린샷
![image](https://github.com/WhatToDo6/WhatToDo/assets/129318957/0a02f26c-f701-41e1-8345-069e6423255f)
![image](https://github.com/WhatToDo6/WhatToDo/assets/129318957/601b822f-1fbf-4ca7-a090-fef38cd5a99a)

## 📝 기타 논의 사항
