### PR TITLE
MangerProfile(담당자) 공통 컴포넌트 생성 

### DIFF
--- a/src/components/common/manager-profile/ManagerProfile.module.scss
+++ b/src/components/common/manager-profile/ManagerProfile.module.scss
@@ -1,0 +1,34 @@
+@import '@/src/styles/global.scss';
+
+.container {
+  display: flex;
+  align-items: center;
+
+  &.dropdown {
+    gap: 0.6rem;
+
+    span {
+      @include font-style(1.6rem, 400, normal);
+    }
+  }
+
+  &.dashboardHeader {
+    gap: 1.2rem;
+
+    span {
+      @include font-style(1.6rem, 500, normal);
+    }
+  }
+
+  &.card {
+    gap: 0.8rem;
+
+    span {
+      @include font-style(1.4rem, 400, normal);
+    }
+  }
+
+  span {
+    color: $color-black-200;
+  }
+}

--- a/src/components/common/manager-profile/index.tsx
+++ b/src/components/common/manager-profile/index.tsx
@@ -1,0 +1,44 @@
+import Image from 'next/image'
+
+import basicImg from '@/public/icons/temp-circle-1.svg'
+
+import S from './ManagerProfile.module.scss'
+
+interface ManagerProfileProps {
+  type: 'dropdown' | 'dashboardHeader' | 'card'
+  profileImageUrl: string | null
+  nickname: string
+}
+
+/**
+ *
+ * @param type - 'dropdown' | 'dashboardHeader' | 'card'
+ * @param profileImageUrl - string | null
+ * @param nickname - string
+ * @returns
+ */
+
+function ManagerProfile({
+  profileImageUrl,
+  nickname,
+  type,
+}: ManagerProfileProps) {
+  const SIZE = {
+    dashboardHeader: 38,
+    dropdown: 26,
+    card: 34,
+  }
+  return (
+    <div className={`${S.container} ${S[type]}`}>
+      <Image
+        width={SIZE[type]}
+        height={SIZE[type]}
+        src={profileImageUrl ? profileImageUrl : basicImg}
+        alt="profileImg"
+      />
+      <span>{nickname}</span>
+    </div>
+  )
+}
+
+export default ManagerProfile

--- a/src/components/dashboard/header/DashboardHeader.module.scss
+++ b/src/components/dashboard/header/DashboardHeader.module.scss
@@ -76,24 +76,6 @@
   }
 }
 
-.loginInfoBox {
-  display: flex;
-  align-items: center;
-  gap: 1.2rem;
-
-  .imageBox {
-    width: 3.8rem;
-    height: 3.8rem;
-    border-radius: 50%;
-    background-color: $color-green;
-  }
-
-  span {
-    @include font-style(1.6rem, 500, normal);
-    color: $color-black-200;
-  }
-}
-
 .memberImgBox {
   display: flex;
 }

--- a/src/components/dashboard/header/index.tsx
+++ b/src/components/dashboard/header/index.tsx
@@ -11,10 +11,10 @@ import tempCircle2 from '@/public/icons/temp-circle-2.svg'
 import tempCircle3 from '@/public/icons/temp-circle-3.svg'
 import tempCircle4 from '@/public/icons/temp-circle-4.svg'
 import tempCircle5 from '@/public/icons/temp-circle-5.svg'
-import tempCircle6 from '@/public/icons/temp-circle-6.svg'
 import { UserType } from '@/src/types/mydashboard'
 
 import S from './DashboardHeader.module.scss'
+import ManagerProfile from '../../common/manager-profile'
 
 const MEMBERS = [
   {
@@ -164,19 +164,11 @@ function DashboardHeader({ pathname }: DashboardHeaderProps) {
             <Image width={0} height={38} src={barIcon} alt="bar" />
           </>
         )}
-        <div className={S.loginInfoBox}>
-          <Image
-            width={38}
-            height={38}
-            src={
-              myUserData.profileImageUrl
-                ? myUserData.profileImageUrl
-                : tempCircle6
-            }
-            alt="myImg"
-          />
-          <span>{myUserData.nickname}</span>
-        </div>
+        <ManagerProfile
+          profileImageUrl={myUserData.profileImageUrl}
+          nickname={myUserData.nickname}
+          type="dashboardHeader"
+        />
       </div>
     </div>
   )


### PR DESCRIPTION
## 🚀 주요 변경 사항

- MangerProfile 공통 컴포넌트 생성 하였습니다
- 노션: https://www.notion.so/7932d43a296d48c69851cc06d0187986?p=f382e649b74d4cd7a6564131f5eeeac5&pm=c
- type 을 'dropdown' | 'dashboardHeader' | 'card' 이런 식으로 나눴는데 할일 카드 모달에서의 쓸때 타입은 'card'로 하였습니다. 
추후에 더 나은 이름이 생각나면 수정 하겠습니다.
- profileImg 가 null 일 수도 있어서 없으면 기본 이미지 일단 주황색 원으로 설정했습니다. 추후에 더 나은 이미지로 교체 하겠습니다.
- 반응형은 다른 부분 기능 구현 후에 진행하겠습니다!

## 🖼️ 스크린샷
![image](https://github.com/WhatToDo6/WhatToDo/assets/107683008/c4a77ed3-a862-4328-883d-8baa3c598278)
![image](https://github.com/WhatToDo6/WhatToDo/assets/107683008/f04c37c9-71ea-42ec-836b-23be8edfe2ad)



## 📝 기타 논의 사항