### PR TITLE
컬럼 삭제, 추가 모달 연결 및 기능 구현 완료

### DIFF
--- a/pages/api/columns.ts
+++ b/pages/api/columns.ts
@@ -1,8 +1,5 @@
 import AXIOS from '@/lib/axios'
-import {
-  ColumnDataType,
-  ColumnTitleType,
-} from '@/src/types/dashboard.interface'
+import { ColumnDataType } from '@/src/types/dashboard.interface'
 
 export async function getColumns(
   id: number | undefined,
@@ -25,7 +22,7 @@ export async function getColumns(
 
 export async function putColumns(
   id: number | undefined,
-  data: ColumnTitleType,
+  data: { title: string },
 ): Promise<ColumnDataType[]> {
   if (!id) {
     throw new Error('칼럼id가 필요합니다.')

--- a/pages/api/columns.ts
+++ b/pages/api/columns.ts
@@ -1,5 +1,8 @@
 import AXIOS from '@/lib/axios'
-import { ColumnDataType } from '@/src/types/dashboard.interface'
+import {
+  ColumnDataType,
+  ColumnTitleType,
+} from '@/src/types/dashboard.interface'
 
 export async function getColumns(
   id: number | undefined,
@@ -22,7 +25,7 @@ export async function getColumns(
 
 export async function putColumns(
   id: number | undefined,
-  data: any,
+  data: ColumnTitleType,
 ): Promise<ColumnDataType[]> {
   if (!id) {
     throw new Error('칼럼id가 필요합니다.')

--- a/pages/api/columns.ts
+++ b/pages/api/columns.ts
@@ -1,84 +1,95 @@
 import AXIOS from '@/lib/axios'
 import { ColumnDataType } from '@/src/types/dashboard.interface'
 
-export async function getColumns(
-  id: number | undefined,
-): Promise<ColumnDataType[]> {
-  if (!id) {
-    throw new Error('칼럼id가 필요합니다.')
-  }
+/**
+ * API 요청에 사용될 공통 인증 헤더 반환
+ * @returns {Record<string, string>} 인증 헤더 객체
+ */
+const getAuthHeaders = (): Record<string, string> => ({
+  Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
+  'Content-Type': 'application/json',
+})
+
+/**
+ * 일반적인 API 호출을 수행하는 함수
+ * @param { 'get' | 'post' | 'put' | 'delete'} method - 사용할 HTTP 메소드
+ * @param {string} url - 요청할 URL
+ * @param {Record<string, any> | undefined} data - 요청에 포함될 데이터
+ * @param {boolean} unwrapData - 응답에서 data, data.data를 사용할지 여부
+ * @returns {Promise<any>} 서버로부터의 응답 데이터
+ */
+const apiCall = async (
+  method: 'get' | 'post' | 'put' | 'delete',
+  url: string,
+  data?: Record<string, any>,
+  unwrapData: boolean = true,
+): Promise<any> => {
   try {
-    const accessToken = localStorage.getItem('accessToken')
-    const response = await AXIOS.get(`/columns?dashboardId=${id}`, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    })
-    return response.data.data
+    const options = {
+      method,
+      url,
+      headers: getAuthHeaders(),
+      data,
+    }
+    const response = await AXIOS(options)
+    return unwrapData ? response.data.data : response.data
   } catch (error) {
-    throw new Error('칼럼 데이터를 불러오는 데 실패했습니다.')
+    console.error(`API 호출 에러 (${method} ${url}):`, error)
+    throw new Error('API 처리 중 에러가 발생했습니다.')
   }
 }
 
-export async function putColumns(
+/**
+ * 지정된 대시보드 ID에 대한 칼럼 요청
+ * @param {number | undefined} id - 대시보드 ID
+ * @returns {Promise<ColumnDataType[]>} 칼럼 데이터 배열
+ */
+export const getColumns = async (
+  id: number | undefined,
+): Promise<ColumnDataType[]> => {
+  if (!id) throw new Error('칼럼 ID가 필요합니다.')
+  return await apiCall('get', `/columns?dashboardId=${id}`)
+}
+
+/**
+ * 지정된 ID의 칼럼을 업데이트
+ * @param {number | undefined} id - 칼럼 ID
+ * @param {{ title: string }} data - 수정할 데이터 객체
+ * @returns {Promise<ColumnDataType[]>} 수정된 칼럼 데이터
+ */
+export const putColumns = async (
   id: number | undefined,
   data: { title: string },
-): Promise<ColumnDataType[]> {
-  if (!id) {
-    throw new Error('칼럼id가 필요합니다.')
-  }
-  try {
-    const accessToken = localStorage.getItem('accessToken')
-    const response = await AXIOS.put(`/columns/${id}`, data, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': 'application/json',
-      },
-    })
-    return response.data.data
-  } catch (error) {
-    throw new Error('칼럼 데이터를 수정하는 데 실패했습니다.')
-  }
+): Promise<ColumnDataType[]> => {
+  if (!id) throw new Error('칼럼 ID가 필요합니다.')
+  return await apiCall('put', `/columns/${id}`, data)
 }
 
-export async function deleteColumns(
+/**
+ * 지정된 ID의 칼럼을 삭제
+ * @param {number | undefined} id - 칼럼 ID
+ * @returns {Promise<ColumnDataType[]>} 삭제 후의 칼럼 데이터
+ */
+export const deleteColumns = async (
   id: number | undefined,
-): Promise<ColumnDataType[]> {
-  if (!id) {
-    throw new Error('칼럼id가 필요합니다.')
-  }
-  try {
-    const accessToken = localStorage.getItem('accessToken')
-    const response = await AXIOS.delete(`/columns/${id}`, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    })
-    return response.data.data
-  } catch (error) {
-    throw new Error('칼럼 데이터를 삭제하는 데 실패했습니다.')
-  }
+): Promise<ColumnDataType[]> => {
+  if (!id) throw new Error('칼럼 ID가 필요합니다.')
+  return await apiCall('delete', `/columns/${id}`)
 }
 
-export async function postColumns(
+/**
+ * 새로운 칼럼을 생성
+ * @param {{ title: string | undefined }} data - 생성할 칼럼의 데이터
+ * @param {number | undefined} dashboardId - 대시보드 ID
+ * @returns {Promise<ColumnDataType>} 생성된 칼럼 데이터
+ */
+export const postColumns = async (
   data: { title: string | undefined },
   dashboardId: number | undefined,
-): Promise<ColumnDataType> {
-  try {
-    const accessToken = localStorage.getItem('accessToken')
-    const fullData = {
-      ...data,
-      dashboardId: dashboardId,
-    }
-    const response = await AXIOS.post(`/columns`, fullData, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': 'application/json',
-      },
-    })
-    return response.data
-  } catch (error) {
-    console.error('칼럼 데이터를 추가하는 데 실패했습니다:', error)
-    throw new Error('칼럼 데이터를 추가하는 데 실패했습니다.')
+): Promise<ColumnDataType> => {
+  const fullData = {
+    ...data,
+    dashboardId: dashboardId,
   }
+  return await apiCall('post', `/columns`, fullData, false)
 }

--- a/pages/api/columns.ts
+++ b/pages/api/columns.ts
@@ -40,3 +40,22 @@ export async function putColumns(
     throw new Error('칼럼 데이터를 수정하는 데 실패했습니다.')
   }
 }
+
+export async function deleteColumns(
+  id: number | undefined,
+): Promise<ColumnDataType[]> {
+  if (!id) {
+    throw new Error('칼럼id가 필요합니다.')
+  }
+  try {
+    const accessToken = localStorage.getItem('accessToken')
+    const response = await AXIOS.delete(`/columns/${id}`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    })
+    return response.data.data
+  } catch (error) {
+    throw new Error('칼럼 데이터를 수정하는 데 실패했습니다.')
+  }
+}

--- a/pages/api/columns.ts
+++ b/pages/api/columns.ts
@@ -56,6 +56,29 @@ export async function deleteColumns(
     })
     return response.data.data
   } catch (error) {
-    throw new Error('칼럼 데이터를 수정하는 데 실패했습니다.')
+    throw new Error('칼럼 데이터를 삭제하는 데 실패했습니다.')
+  }
+}
+
+export async function postColumns(
+  data: { title: string | undefined },
+  dashboardId: number | undefined,
+): Promise<ColumnDataType> {
+  try {
+    const accessToken = localStorage.getItem('accessToken')
+    const fullData = {
+      ...data,
+      dashboardId: dashboardId,
+    }
+    const response = await AXIOS.post(`/columns`, fullData, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+    })
+    return response.data
+  } catch (error) {
+    console.error('칼럼 데이터를 추가하는 데 실패했습니다:', error)
+    throw new Error('칼럼 데이터를 추가하는 데 실패했습니다.')
   }
 }

--- a/pages/dashboards/[id]/index.tsx
+++ b/pages/dashboards/[id]/index.tsx
@@ -1,12 +1,17 @@
 import { useRouter } from 'next/router'
 import { useState, useEffect } from 'react'
 
-import { getColumns } from '@/pages/api/columns'
+import { getColumns, postColumns } from '@/pages/api/columns'
 import Layout from '@/src/components/common/layout'
+import Modal from '@/src/components/common/modal'
+import ModalDashBoard from '@/src/components/common/modal/modal-dashboard'
 import Column from '@/src/components/dashboard/column'
 import ColumnLayout from '@/src/components/dashboard/column/column-layout'
 import DashboardButton from '@/src/components/dashboard/dashboard-button'
-import { ColumnDataType } from '@/src/types/dashboard.interface'
+import {
+  ColumnDataType,
+  ColumnTitleType,
+} from '@/src/types/dashboard.interface'
 
 import S from './DashboardId.module.scss'
 
@@ -16,6 +21,27 @@ const DashboardIdPage = () => {
   } = useRouter()
   const [columns, setColumns] = useState<ColumnDataType[]>([])
   const [isLoading, setIsLoading] = useState(true)
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
+  const handleClick = () => {
+    setIsModalOpen(true)
+  }
+
+  const handleAPI = async (data: ColumnTitleType) => {
+    try {
+      const requestData = {
+        title: data.newColumn,
+      }
+      if (!id) throw new Error('대시보드 ID가 제공되지 않았습니다.')
+      const newColumn = await postColumns(requestData, Number(id))
+      if (newColumn) {
+        setColumns((prevColumns) => [...prevColumns, newColumn])
+        setIsModalOpen(false)
+      }
+    } catch (error) {
+      console.error('컬럼 데이터를 업데이트하는 데 실패했습니다:', error)
+    }
+  }
 
   useEffect(() => {
     const fetchColumns = async () => {
@@ -44,9 +70,23 @@ const DashboardIdPage = () => {
         {columns.map((column) => (
           <Column key={column.id} {...column} />
         ))}
-        <div className={S.addWrapper}>
+        <div className={S.addWrapper} onClick={handleClick}>
           <DashboardButton type="addColumn" />
         </div>
+        {isModalOpen && (
+          <Modal setIsOpen={setIsModalOpen}>
+            <ModalDashBoard
+              title="새 칼럼 생성"
+              inputTitle="이름"
+              inputType="newColumn"
+              placeholder="새로운 프로젝트"
+              leftButtonText="취소"
+              rightButtonText="생성"
+              currentColumn=""
+              onSubmit={handleAPI}
+            />
+          </Modal>
+        )}
       </ColumnLayout>
     </Layout>
   )

--- a/pages/dashboards/[id]/index.tsx
+++ b/pages/dashboards/[id]/index.tsx
@@ -40,7 +40,7 @@ const DashboardIdPage = () => {
 
   return (
     <Layout>
-      <ColumnLayout>
+      <ColumnLayout columns={columns} setColumns={setColumns}>
         {columns.map((column) => (
           <Column key={column.id} {...column} />
         ))}

--- a/src/components/common/modal/modal-dashboard/index.tsx
+++ b/src/components/common/modal/modal-dashboard/index.tsx
@@ -11,7 +11,7 @@ import Input from '../../input'
 import ModalDeleteColumn from '../modal-deletecolumn'
 
 interface ModalDashBoardProps {
-  columnId: number | undefined
+  columnId?: number | undefined
   title: string
   inputTitle: string
   inputType: 'newColumn' | 'columnName' | 'email'

--- a/src/components/common/modal/modal-dashboard/index.tsx
+++ b/src/components/common/modal/modal-dashboard/index.tsx
@@ -65,6 +65,7 @@ const ModalDashBoard = ({
   const handleFormSubmit: SubmitHandler<InputFormValues> = (data) => {
     modalStatus.setIsOpen.call(null, false)
     moveTo && router.push(moveTo)
+    console.log('Received columnName:', data)
     onSubmit(data)
   }
 

--- a/src/components/common/modal/modal-dashboard/index.tsx
+++ b/src/components/common/modal/modal-dashboard/index.tsx
@@ -1,15 +1,17 @@
 import { useRouter } from 'next/router'
-import { useContext } from 'react'
+import { useContext, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 
 import { InputFormValues } from '@/src/types/input'
 
 import S from './ModalColumn.module.scss'
-import { ModalContext } from '..'
+import Modal, { ModalContext } from '..'
 import OptionButton from '../../button/option'
 import Input from '../../input'
+import ModalDeleteColumn from '../modal-deletecolumn'
 
 interface ModalDashBoardProps {
+  columnId: number | undefined
   title: string
   inputTitle: string
   inputType: 'newColumn' | 'columnName' | 'email'
@@ -23,7 +25,7 @@ interface ModalDashBoardProps {
 }
 
 /**
- *
+ * @param columnId - 컬럼id
  * @param title - 모달 제목
  * @param inputTitle - input 제목
  * @param inputType - input type
@@ -37,6 +39,7 @@ interface ModalDashBoardProps {
  * @returns
  */
 const ModalDashBoard = ({
+  columnId,
   title,
   inputTitle,
   inputType,
@@ -50,6 +53,7 @@ const ModalDashBoard = ({
 }: ModalDashBoardProps) => {
   const router = useRouter()
   const modalStatus = useContext(ModalContext)
+  const [isModalOpen, setIsModalOpen] = useState(false)
 
   const {
     register,
@@ -65,14 +69,13 @@ const ModalDashBoard = ({
   const handleFormSubmit: SubmitHandler<InputFormValues> = (data) => {
     modalStatus.setIsOpen.call(null, false)
     moveTo && router.push(moveTo)
-    console.log('Received columnName:', data)
     onSubmit(data)
   }
 
   const handleDeleteClick = () => {
-    modalStatus.setIsOpen.call(null, false)
-    // TODO 칼럼 삭제하기 기능 추가 해야 합니다 !
+    setIsModalOpen(true)
   }
+
   return (
     <form
       className={`${S.container} ${errors[inputType] ? S.error : ''} ${showDeleteButton && S.delete}`}
@@ -103,6 +106,16 @@ const ModalDashBoard = ({
           onLeftClick={handleLeftClick}
         />
       </div>
+      {isModalOpen && (
+        <Modal setIsOpen={modalStatus.setIsOpen}>
+          <ModalDeleteColumn
+            columnId={columnId}
+            content="칼럼의 모든 카드가 삭제됩니다."
+            leftButtonText="취소"
+            rightButtonText="삭제"
+          />
+        </Modal>
+      )}
     </form>
   )
 }

--- a/src/components/common/modal/modal-deletecolumn/index.tsx
+++ b/src/components/common/modal/modal-deletecolumn/index.tsx
@@ -1,11 +1,15 @@
 import { useRouter } from 'next/router'
 import { useContext } from 'react'
 
+import { deleteColumns } from '@/pages/api/columns'
+import { useColumnsContext } from '@/src/components/dashboard/column/column-layout'
+
 import S from './ModalDeleteColumn.module.scss'
 import { ModalContext } from '..'
 import OptionButton from '../../button/option'
 
 interface ModalDeleteColumn {
+  columnId: number | undefined
   content: string
   leftButtonText: string
   rightButtonText: string
@@ -13,7 +17,7 @@ interface ModalDeleteColumn {
 }
 
 /**
- *
+ * @param columnId - 컬럼id
  * @param content - 모달 내부 내용
  * @param leftButtonText - 왼쪽 버튼 텍스트
  * @param leftButtonText - 오른쪽 버튼 텍스트
@@ -21,23 +25,33 @@ interface ModalDeleteColumn {
  * @returns
  */
 const ModalDeleteColumn = ({
+  columnId,
   content,
   leftButtonText,
   rightButtonText,
   moveTo,
 }: ModalDeleteColumn) => {
   const router = useRouter()
-  const modalStaus = useContext(ModalContext)
+  const modalStatus = useContext(ModalContext)
+  const { setColumns } = useColumnsContext()
 
   const handleLeftClick = () => {
-    modalStaus.setIsOpen.call(null, false)
+    modalStatus.setIsOpen.call(null, false)
     moveTo && router.push(moveTo)
   }
 
-  const handleRigthClick = () => {
-    modalStaus.setIsOpen.call(null, false)
-    moveTo && router.push(moveTo)
-    // TO DO 삭제 버튼 클릭 시 수행해야할 부분 작성해주세요 !
+  const handleRightClick = async () => {
+    try {
+      await deleteColumns(columnId)
+      setColumns((prevColumns) =>
+        prevColumns.filter((column) => column.id !== columnId),
+      )
+      modalStatus.setIsOpen(false)
+      moveTo && router.push(moveTo)
+    } catch (error) {
+      console.error('Failed to delete column:', error)
+      modalStatus.setIsOpen(false)
+    }
   }
 
   return (
@@ -51,7 +65,7 @@ const ModalDeleteColumn = ({
           leftText={leftButtonText}
           rightText={rightButtonText}
           onLeftClick={handleLeftClick}
-          onRightClick={handleRigthClick}
+          onRightClick={handleRightClick}
         />
       </div>
     </div>

--- a/src/components/dashboard/column/column-header/index.tsx
+++ b/src/components/dashboard/column/column-header/index.tsx
@@ -56,6 +56,7 @@ const ColumnHeader = ({
       {isModalOpen && (
         <Modal setIsOpen={setIsModalOpen}>
           <ModalDashBoard
+            columnId={columnId}
             title="컬럼 관리"
             inputTitle="이름"
             inputType="columnName"

--- a/src/components/dashboard/column/column-header/index.tsx
+++ b/src/components/dashboard/column/column-header/index.tsx
@@ -26,11 +26,11 @@ const ColumnHeader = ({
 
   const handleAPI = async (data: ColumnTitleType) => {
     try {
-      const requestData = {
-        title: data.title,
+      const requestData: { title: string } = {
+        title: data.columnName,
       }
       await putColumns(columnId, requestData)
-      setTitle(data.title)
+      setTitle(data.columnName)
       setIsModalOpen(false)
     } catch (error) {
       console.error('컬럼 데이터를 업데이트하는 데 실패했습니다:', error)

--- a/src/components/dashboard/column/column-header/index.tsx
+++ b/src/components/dashboard/column/column-header/index.tsx
@@ -4,7 +4,10 @@ import { useState } from 'react'
 import { putColumns } from '@/pages/api/columns'
 import Modal from '@/src/components/common/modal'
 import ModalDashBoard from '@/src/components/common/modal/modal-dashboard'
-import { ColumnHeaderType } from '@/src/types/dashboard.interface'
+import {
+  ColumnHeaderType,
+  ColumnTitleType,
+} from '@/src/types/dashboard.interface'
 
 import S from './ColumnHeader.module.scss'
 import { SETTING } from '../constants'
@@ -15,19 +18,19 @@ const ColumnHeader = ({
   columnId,
 }: ColumnHeaderType) => {
   const [isModalOpen, setIsModalOpen] = useState(false)
-  const [title, setTitle] = useState(initialTitle) // State to manage the title
+  const [title, setTitle] = useState(initialTitle)
 
   const handleClick = () => {
     setIsModalOpen(true)
   }
 
-  const handleAPI = async (data: any) => {
+  const handleAPI = async (data: ColumnTitleType) => {
     try {
       const requestData = {
-        title: data.columnName,
+        title: data.title,
       }
       await putColumns(columnId, requestData)
-      setTitle(data.columnName) // Update title state on successful API call
+      setTitle(data.title)
       setIsModalOpen(false)
     } catch (error) {
       console.error('컬럼 데이터를 업데이트하는 데 실패했습니다:', error)

--- a/src/components/dashboard/column/column-layout/index.tsx
+++ b/src/components/dashboard/column/column-layout/index.tsx
@@ -1,9 +1,41 @@
+import { createContext, useContext } from 'react'
+
+import { ColumnDataType } from '@/src/types/dashboard.interface'
+
 import S from './ColumnLayout.module.scss'
 
 import type { ChildrenProps } from '@/src/types/commonType'
 
-const ColumnLayout = ({ children }: ChildrenProps) => {
-  return <main className={S.container}>{children}</main>
+interface ColumnsContextType {
+  columns: ColumnDataType[]
+  setColumns: React.Dispatch<React.SetStateAction<ColumnDataType[]>>
 }
 
-export default ColumnLayout
+const ColumnsContext = createContext<ColumnsContextType | undefined>(undefined)
+
+export const useColumnsContext = () => {
+  const context = useContext(ColumnsContext)
+  if (!context) {
+    throw new Error()
+  }
+  return context
+}
+
+interface ColumnsProviderProps extends ChildrenProps {
+  columns: ColumnDataType[]
+  setColumns: React.Dispatch<React.SetStateAction<ColumnDataType[]>>
+}
+
+export const ColumnsProvider = ({
+  children,
+  columns,
+  setColumns,
+}: ColumnsProviderProps) => {
+  return (
+    <ColumnsContext.Provider value={{ columns, setColumns }}>
+      <main className={S.container}>{children}</main>
+    </ColumnsContext.Provider>
+  )
+}
+
+export default ColumnsProvider

--- a/src/types/dashboard.interface.ts
+++ b/src/types/dashboard.interface.ts
@@ -1,3 +1,7 @@
+export interface ColumnTitleType {
+  title: string
+}
+
 export interface ColumnDataType {
   id?: number
   title: string

--- a/src/types/dashboard.interface.ts
+++ b/src/types/dashboard.interface.ts
@@ -1,5 +1,6 @@
 export interface ColumnTitleType {
-  columnName: string
+  columnName?: string
+  newColumn?: string
 }
 
 export interface ColumnDataType {

--- a/src/types/dashboard.interface.ts
+++ b/src/types/dashboard.interface.ts
@@ -1,5 +1,5 @@
 export interface ColumnTitleType {
-  title: string
+  columnName: string
 }
 
 export interface ColumnDataType {


### PR DESCRIPTION
## 🚀 주요 변경 사항

### 컬럼 삭제 모달 연결 및 기능 구현
### 컬럼 추가 모달 연결 및 기능 구현

- 수지님과 연아님이 만들어두신 공통 모달 컴포넌트와 컬럼 연결했습니다.
- 각각 기능 구현 완료하였습니다.
- 삭제 시 컬럼 state가 변경이 되어야 하는데 prop으로 넘겨주기엔 prop 깊이가 너무 깊어져서 contextAPI 사용했습니다.

### columns의 api 요청 메서드(get, put, delete, post) 코드 정리 및 JSDoc 작성

- columns의 api 요청 메서드들이 겹치는 로직이 너무 많아서 공통으로 뽑았습니다.
- get, put, delete의 경우 return 값으로 reponse.data.data를 반환하는 데 반해 post는 response.data를 반환해서 삼항 연산자 조건문을 달아놓았습니다.

## 🖼️ 스크린샷

![ddd](https://github.com/WhatToDo6/WhatToDo/assets/108844881/c8765274-e755-4870-8691-4e3eae379bae)


## 📝 기타 논의 사항

- 중복 메시지에 대한 질문이 있습니다