### PR TITLE
이미지 업로드 함수 분리

### DIFF
--- a/pages/api/imageUpload.ts
+++ b/pages/api/imageUpload.ts
@@ -1,0 +1,42 @@
+import AXIOS from '@/lib/axios'
+
+/**
+ *
+ * @param event
+ * @param setUploadedImageUrl - 이미지 업로드 관리할 setState
+ * @param columnId - (optional) columnID
+ * @returns
+ */
+export const handleImageChange = (
+  event: React.ChangeEvent<HTMLInputElement>,
+  setUploadedImageUrl: React.Dispatch<React.SetStateAction<string>>,
+  columnId?: number,
+) => {
+  const accessToken = localStorage.getItem('accessToken')
+  const files = event.target.files
+
+  const imagePath = columnId
+    ? `/columns/${columnId}/card-image`
+    : '/users/me/image'
+
+  if (files && files[0] && accessToken) {
+    const formData = new FormData()
+    formData.append('image', files[0])
+
+    AXIOS.post(imagePath, formData, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    })
+      .then((res) => {
+        if (columnId) {
+          setUploadedImageUrl(res.data.imageUrl)
+        } else {
+          setUploadedImageUrl(res.data.profileImageUrl)
+        }
+      })
+      .catch((err) => {
+        console.error(err)
+      })
+  }
+}

--- a/src/components/mypage/profile-form/index.tsx
+++ b/src/components/mypage/profile-form/index.tsx
@@ -1,7 +1,8 @@
-import { useState, ChangeEvent, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 import { useForm, SubmitHandler } from 'react-hook-form'
 
 import AXIOS from '@/lib/axios'
+import { handleImageChange } from '@/pages/api/imageUpload'
 import BorderButton from '@/src/components/common/button/border'
 import Input from '@/src/components/common/input'
 import { useUser } from '@/src/context/users'
@@ -29,27 +30,6 @@ const ProfileForm = () => {
     reset,
     formState: { errors },
   } = useForm<InputFormValues>({ mode: 'onBlur' })
-
-  const handleImageChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const accessToken = localStorage.getItem('accessToken')
-    const files = event.target.files
-    if (files && files[0] && accessToken) {
-      const formData = new FormData()
-      formData.append('image', files[0])
-
-      AXIOS.post('/users/me/image', formData, {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      })
-        .then((res) => {
-          setUploadedImageUrl(res.data.profileImageUrl)
-        })
-        .catch((err) => {
-          console.error(err)
-        })
-    }
-  }
 
   const onSubmit: SubmitHandler<InputFormValues> = (data) => {
     const accessToken = localStorage.getItem('accessToken')
@@ -94,7 +74,9 @@ const ProfileForm = () => {
         <div className={S.imgContainer}>
           <InputProfileImage
             profileImageUrl={uploadedImageUrl}
-            handleImageChange={handleImageChange}
+            handleImageChange={(event) =>
+              handleImageChange(event, setUploadedImageUrl)
+            }
           />
         </div>
         <div className={S.textContainer}>


### PR DESCRIPTION
## 🚀 주요 변경 사항

- 계정관리 이미지 input에서 사용되는 이미지 업로드 했을 때 post 요청을 보내는 함수가 모달 쪽에서도 사용이 되어 분리하였습니다.
- columnId의 유무에 따라 imagePath와 res.data. 이쪽 부분을 다르게 구현하였습니다. 
- 모달에 사용하는 함수에는 columnId를 넘겨줘야 합니다 @innerstella @JaeBeen95 

## 🖼️ 스크린샷

## 📝 기타 논의 사항
저는 이 이미지 업로드가 error 관리가 필요 없다고 생각하여 사용할 때 inputProfileImage를 직접 불러와서 사용을 하고 있습니다. 
![image](https://github.com/WhatToDo6/WhatToDo/assets/129318957/6359fde4-f475-4a9c-a738-39472325a663)

하지만 지금 수지님이 만드신 모달에는 
![image](https://github.com/WhatToDo6/WhatToDo/assets/129318957/eed234b9-8dab-4751-8e6f-479376dc9b77)
이렇게 적용되고 있는데 제가 바꾸기에는 컨플릭트가 발생할 것 같아서 우선 함수만 분리했습니다.
추후 이 부분을 작업 해야할 것 같습니다. 