### PR TITLE
헤더 프로필 클릭 시 팝오버 생성

### DIFF
--- a/src/components/common/manager-profile/ManagerProfile.module.scss
+++ b/src/components/common/manager-profile/ManagerProfile.module.scss
@@ -46,4 +46,39 @@
 
 .img {
   border-radius: 100%;
+  cursor: pointer;
+}
+
+.popoverContainer {
+  position: absolute;
+  top: 6rem;
+  right: 9.5rem;
+  width: 12rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 0.6rem;
+  border: 0.1rem solid $color-gray-300;
+  background-color: $color-white;
+  box-shadow: 0 0.4rem 2rem 0 rgba(0, 0, 0, 0.08);
+  cursor: pointer;
+}
+
+.popoverOption {
+  width: 100%;
+  padding: 0.8rem 0;
+  color: $color-black-200;
+  border: none;
+  border-radius: 0.4rem;
+  @include font-style(1.6rem, 500, 2.4rem);
+  text-align: center;
+  background-color: $color-white;
+  cursor: pointer;
+  outline: none;
+
+  &:hover {
+    color: $color-violet-200;
+    background-color: $color-violet-100;
+  }
 }

--- a/src/components/common/manager-profile/index.tsx
+++ b/src/components/common/manager-profile/index.tsx
@@ -1,4 +1,6 @@
 import Image from 'next/image'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
 
 import basicImg from '@/public/icons/temp-circle-1.svg'
 
@@ -8,6 +10,7 @@ interface ManagerProfileProps {
   type: 'dropdown' | 'dashboardHeader' | 'card'
   profileImageUrl: string | null
   nickname: string
+  showPopover?: boolean
 }
 
 /**
@@ -15,6 +18,7 @@ interface ManagerProfileProps {
  * @param type - 'dropdown' | 'dashboardHeader' | 'card'
  * @param profileImageUrl - string | null
  * @param nickname - string
+ * @param showPopover - (optional) 팝오버의 유무를 결정
  * @returns
  */
 
@@ -22,12 +26,30 @@ function ManagerProfile({
   profileImageUrl,
   nickname,
   type,
+  showPopover = false,
 }: ManagerProfileProps) {
   const SIZE = {
     dashboardHeader: 38,
     dropdown: 26,
     card: 34,
   }
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false)
+  const router = useRouter()
+
+  const togglePopover = () => {
+    setIsPopoverOpen((prev) => !prev)
+  }
+
+  const handleMyInfoClick = () => {
+    router.push('/mypage')
+    setIsPopoverOpen((prev) => !prev)
+  }
+
+  const handleLogout = () => {
+    //TODO 로그아웃 구현
+    setIsPopoverOpen((prev) => !prev)
+  }
+
   return (
     <div className={`${S.container} ${S[type]}`}>
       <Image
@@ -36,7 +58,18 @@ function ManagerProfile({
         src={profileImageUrl ? profileImageUrl : basicImg}
         alt="profileImg"
         className={S.img}
+        onClick={togglePopover}
       />
+      {showPopover && isPopoverOpen && (
+        <div className={S.popoverContainer}>
+          <button className={S.popoverOption} onClick={handleMyInfoClick}>
+            내 정보
+          </button>
+          <button className={S.popoverOption} onClick={handleLogout}>
+            로그아웃
+          </button>
+        </div>
+      )}
       <span>{nickname}</span>
     </div>
   )

--- a/src/components/dashboard/header/index.tsx
+++ b/src/components/dashboard/header/index.tsx
@@ -138,6 +138,7 @@ function DashboardHeader({ pathname }: DashboardHeaderProps) {
             profileImageUrl={userData.profileImageUrl}
             nickname={userData.nickname}
             type="dashboardHeader"
+            showPopover={true}
           />
         </div>
       </div>


### PR DESCRIPTION
## 🚀 주요 변경 사항

- 헤더 프로필 클릭 시 내정보와 로그아웃을 담고 있는 팝오버가 나옵니다!
- ManagerProfile이 헤더 뿐만 아니라 다른 모달에서도 사용이 되므로 showPopover라는 값을 optional로 주어 다른 곳에서는 팝오버가 생기지 않도록 구현했습니다.

## 🖼️ 스크린샷
![localhost_3000_mydashboard-Chrome-2024-04-24-15-31-03](https://github.com/WhatToDo6/WhatToDo/assets/129318957/db12e522-82cf-4e5e-ab38-d423352259c0)


## 📝 기타 논의 사항
