### PR TITLE
ModalTask 연결, 댓글 get,put,delete 기능, 무한스크롤 구현 

### DIFF
--- a/pages/api/comments.ts
+++ b/pages/api/comments.ts
@@ -1,4 +1,5 @@
 import AXIOS from '@/lib/axios'
+import { CommentsType } from '@/src/types/dashboard.interface'
 
 const getAuthHeaders = (): Record<string, string> => ({
   Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
@@ -41,15 +42,15 @@ export const getComments = async (
 
 export const putComments = async (
   id: number | undefined,
-  data: { title: string | undefined },
-): Promise<ColumnDataType[]> => {
+  data: { content: string },
+): Promise<CommentsType[]> => {
   if (!id) throw new Error('댓글 ID가 필요합니다.')
   return await apiCall('put', `/comments/${id}`, data)
 }
 
 export const deleteComment = async (
   id: number | undefined,
-): Promise<ColumnDataType[]> => {
+): Promise<CommentsType[]> => {
   if (!id) throw new Error('댓글 ID가 필요합니다.')
   return await apiCall('delete', `/comments/${id}`)
 }

--- a/pages/api/comments.ts
+++ b/pages/api/comments.ts
@@ -1,0 +1,40 @@
+import AXIOS from '@/lib/axios'
+
+const getAuthHeaders = (): Record<string, string> => ({
+  Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
+  'Content-Type': 'application/json',
+})
+
+const apiCall = async (
+  method: 'get' | 'post' | 'put' | 'delete',
+  url: string,
+  data?: Record<string, any>,
+): Promise<any> => {
+  try {
+    const options = {
+      method,
+      url,
+      headers: getAuthHeaders(),
+      data,
+    }
+    const response = await AXIOS(options)
+    return response.data
+  } catch (error) {
+    console.error(`API 호출 에러 (${method} ${url}):`, error)
+    throw new Error('API 처리 중 에러가 발생했습니다.')
+  }
+}
+
+export const getComments = async (
+  cardId: number,
+  cursorId: number | null,
+  firstFetch: boolean = false,
+): Promise<any> => {
+  //임시 타입
+  const path = `/comments?size=3&cardId=${cardId}${!firstFetch && cursorId ? `&cursorId=${cursorId}` : ''}`
+  const response = await apiCall('get', path)
+  return {
+    data: response.comments,
+    nextCursorId: response.cursorId,
+  }
+}

--- a/pages/api/comments.ts
+++ b/pages/api/comments.ts
@@ -38,3 +38,11 @@ export const getComments = async (
     nextCursorId: response.cursorId,
   }
 }
+
+export const putComments = async (
+  id: number | undefined,
+  data: { title: string | undefined },
+): Promise<ColumnDataType[]> => {
+  if (!id) throw new Error('칼럼 ID가 필요합니다.')
+  return await apiCall('put', `/comments/${id}`, data)
+}

--- a/pages/api/comments.ts
+++ b/pages/api/comments.ts
@@ -43,6 +43,13 @@ export const putComments = async (
   id: number | undefined,
   data: { title: string | undefined },
 ): Promise<ColumnDataType[]> => {
-  if (!id) throw new Error('칼럼 ID가 필요합니다.')
+  if (!id) throw new Error('댓글 ID가 필요합니다.')
   return await apiCall('put', `/comments/${id}`, data)
+}
+
+export const deleteComment = async (
+  id: number | undefined,
+): Promise<ColumnDataType[]> => {
+  if (!id) throw new Error('댓글 ID가 필요합니다.')
+  return await apiCall('delete', `/comments/${id}`)
 }

--- a/src/components/common/modal/modal-deletecolumn/index.tsx
+++ b/src/components/common/modal/modal-deletecolumn/index.tsx
@@ -49,7 +49,7 @@ const ModalDeleteColumn = ({
       modalStatus.setIsOpen(false)
       moveTo && router.push(moveTo)
     } catch (error) {
-      console.error('Failed to delete column:', error)
+      console.error('컬럼을 삭제하는 데 실패했습니다.:', error)
       modalStatus.setIsOpen(false)
     }
   }

--- a/src/components/common/modal/modal-task/ModalTask.module.scss
+++ b/src/components/common/modal/modal-task/ModalTask.module.scss
@@ -40,6 +40,7 @@
   position: absolute;
   top: 3.2rem;
   right: 8.4rem;
+  cursor: pointer;
 
   @include mobile {
     width: 2.4rem;
@@ -96,6 +97,7 @@
   position: absolute;
   top: 3.2rem;
   right: 2.8rem;
+  cursor: pointer;
 
   @include mobile {
     top: 1.2rem;

--- a/src/components/common/modal/modal-task/ModalTask.module.scss
+++ b/src/components/common/modal/modal-task/ModalTask.module.scss
@@ -3,13 +3,15 @@
 .container {
   position: relative;
   width: 73rem;
-  height: auto;
+  height: 76.3rem;
   display: flex;
   flex-direction: column;
   gap: 2.4rem;
   padding: 3.2rem 2.8rem;
   border-radius: 0.8rem;
   background-color: $color-white;
+  overflow-y: scroll;
+  -ms-overflow-style: none;
 
   @include tablet {
     width: 68rem;
@@ -18,6 +20,10 @@
   @include mobile {
     width: 32.7rem;
     padding: 4rem 2rem 2.8rem;
+  }
+
+  &::-webkit-scrollbar {
+    display: none;
   }
 }
 

--- a/src/components/common/modal/modal-task/comment-form/index.tsx
+++ b/src/components/common/modal/modal-task/comment-form/index.tsx
@@ -1,0 +1,24 @@
+import { MouseEvent } from 'react'
+
+import S from './CommentForm.module.scss'
+import BorderButton from '../../../button/border'
+
+const CommentForm = () => {
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    //TODO 입력 버튼 누르면 수행해야하는 함수 구현해야 합니다!
+    e.preventDefault()
+  }
+  return (
+    <form className={S.container}>
+      <span className={S.comment}>댓글</span>
+      <textarea className={S.input} placeholder="댓글 작성하기" />
+      <div className={S.button}>
+        <BorderButton size="change" color="white" onClick={handleClick}>
+          입력
+        </BorderButton>
+      </div>
+    </form>
+  )
+}
+
+export default CommentForm

--- a/src/components/common/modal/modal-task/comment/Comment.module.scss
+++ b/src/components/common/modal/modal-task/comment/Comment.module.scss
@@ -79,6 +79,7 @@
   color: $color-gray-400;
   @include font-style(1.2rem, 400, normal);
   text-decoration-line: underline;
+  cursor: pointer;
 
   @include mobile {
     @include font-style(1rem, 400, normal);

--- a/src/components/common/modal/modal-task/comment/index.tsx
+++ b/src/components/common/modal/modal-task/comment/index.tsx
@@ -2,18 +2,9 @@ import Image from 'next/image'
 import { useState } from 'react'
 
 import { putComments } from '@/pages/api/comments'
+import { CommentsType } from '@/src/types/dashboard.interface'
 
 import S from './Comment.module.scss'
-
-interface CommentProps {
-  id: number
-  content: string
-  createdAt: string
-  author: {
-    profileImageUrl: string
-    nickname: string
-  }
-}
 
 const Comment = ({
   id: commentId,
@@ -21,7 +12,7 @@ const Comment = ({
   createdAt,
   author,
   onDelete,
-}: CommentProps) => {
+}: CommentsType) => {
   const [isEditing, setIsEditing] = useState(false)
   const [editContent, setEditContent] = useState(initialContent)
   const [content, setContent] = useState(initialContent)

--- a/src/components/common/modal/modal-task/comment/index.tsx
+++ b/src/components/common/modal/modal-task/comment/index.tsx
@@ -15,7 +15,6 @@ interface CommentProps {
 const Comment = ({ id, content, createdAt, author }: CommentProps) => {
   const handleEdit = () => {
     //TODO 댓글 수정 기능을 구현해야 합니다.
-    console.log(id)
   }
 
   const handleDelete = () => {
@@ -25,7 +24,8 @@ const Comment = ({ id, content, createdAt, author }: CommentProps) => {
   return (
     <div className={S.container}>
       <Image
-        src={author.profileImageUrl}
+        //임시 url
+        src="https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/taskify/task_image/3-7_20345_1713591497409.png"
         alt="댓글 프로필"
         width={34}
         height={34}

--- a/src/components/common/modal/modal-task/comment/index.tsx
+++ b/src/components/common/modal/modal-task/comment/index.tsx
@@ -20,6 +20,7 @@ const Comment = ({
   content: initialContent,
   createdAt,
   author,
+  onDelete,
 }: CommentProps) => {
   const [isEditing, setIsEditing] = useState(false)
   const [editContent, setEditContent] = useState(initialContent)
@@ -48,7 +49,7 @@ const Comment = ({
   }
 
   const handleDelete = () => {
-    //TODO 댓글 삭제 기능을 구현해야 합니다.
+    onDelete(commentId)
   }
 
   return (

--- a/src/components/common/modal/modal-task/comment/index.tsx
+++ b/src/components/common/modal/modal-task/comment/index.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image'
+import { useState } from 'react'
 
 import S from './Comment.module.scss'
 
@@ -13,8 +14,21 @@ interface CommentProps {
 }
 
 const Comment = ({ id, content, createdAt, author }: CommentProps) => {
+  const [isEditing, setIsEditing] = useState(false)
+  const [editedContent, setEditedContent] = useState(content)
+
   const handleEdit = () => {
+    setIsEditing(true)
+  }
+
+  const handleSave = () => {
     //TODO 댓글 수정 기능을 구현해야 합니다.
+    setIsEditing(false)
+  }
+
+  const handleCancel = () => {
+    setIsEditing(false)
+    setEditedContent(content)
   }
 
   const handleDelete = () => {
@@ -36,14 +50,35 @@ const Comment = ({ id, content, createdAt, author }: CommentProps) => {
           <span className={S.people}>{author.nickname}</span>
           <p className={S.createdAt}>{createdAt}</p>
         </div>
-        <p className={S.description}>{content}</p>
+        {isEditing ? (
+          <textarea
+            className={S.editTextarea}
+            value={editedContent}
+            onChange={(e) => setEditedContent(e.target.value)}
+          />
+        ) : (
+          <p className={S.description}>{content}</p>
+        )}
         <div className={S.option}>
-          <p className={S.optionText} onClick={handleEdit}>
-            수정
-          </p>
-          <p className={S.optionText} onClick={handleDelete}>
-            삭제
-          </p>
+          {isEditing ? (
+            <>
+              <p className={S.optionText} onClick={handleSave}>
+                저장
+              </p>
+              <p className={S.optionText} onClick={handleCancel}>
+                취소
+              </p>
+            </>
+          ) : (
+            <>
+              <p className={S.optionText} onClick={handleEdit}>
+                수정
+              </p>
+              <p className={S.optionText} onClick={handleDelete}>
+                삭제
+              </p>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/common/modal/modal-task/comment/index.tsx
+++ b/src/components/common/modal/modal-task/comment/index.tsx
@@ -1,6 +1,8 @@
 import Image from 'next/image'
 import { useState } from 'react'
 
+import { putComments } from '@/pages/api/comments'
+
 import S from './Comment.module.scss'
 
 interface CommentProps {
@@ -13,22 +15,36 @@ interface CommentProps {
   }
 }
 
-const Comment = ({ id, content, createdAt, author }: CommentProps) => {
+const Comment = ({
+  id: commentId,
+  content: initialContent,
+  createdAt,
+  author,
+}: CommentProps) => {
   const [isEditing, setIsEditing] = useState(false)
-  const [editedContent, setEditedContent] = useState(content)
+  const [editContent, setEditContent] = useState(initialContent)
+  const [content, setContent] = useState(initialContent)
 
   const handleEdit = () => {
     setIsEditing(true)
   }
 
-  const handleSave = () => {
-    //TODO 댓글 수정 기능을 구현해야 합니다.
-    setIsEditing(false)
+  const handleSave = async () => {
+    try {
+      const requestData: { content: string } = {
+        content: editContent,
+      }
+      await putComments(commentId, requestData)
+      setIsEditing(false)
+      setContent(editContent)
+    } catch (error) {
+      console.error('댓글 데이터를 업데이트하는 데 실패했습니다:', error)
+    }
   }
 
   const handleCancel = () => {
     setIsEditing(false)
-    setEditedContent(content)
+    setEditContent(content)
   }
 
   const handleDelete = () => {
@@ -53,8 +69,8 @@ const Comment = ({ id, content, createdAt, author }: CommentProps) => {
         {isEditing ? (
           <textarea
             className={S.editTextarea}
-            value={editedContent}
-            onChange={(e) => setEditedContent(e.target.value)}
+            value={editContent}
+            onChange={(e) => setEditContent(e.target.value)}
           />
         ) : (
           <p className={S.description}>{content}</p>

--- a/src/components/common/modal/modal-task/index.tsx
+++ b/src/components/common/modal/modal-task/index.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image'
 import { useContext, useEffect, useRef, useState } from 'react'
 
-import { getComments } from '@/pages/api/comments'
+import { deleteComment, getComments } from '@/pages/api/comments'
 import BAR_ICON from '@/public/icons/bar.svg'
 import CLOSE_ICON from '@/public/icons/close.svg'
 import POPOVER_ICON from '@/public/icons/popover.svg'
@@ -65,6 +65,17 @@ const ModalTask = ({
       } catch (error) {
         console.error('댓글을 불러오는 데 실패했습니다.:', error)
       }
+    }
+  }
+
+  const DeleteComments = async (commentId) => {
+    try {
+      await deleteComment(commentId)
+      setComments((prevComments) =>
+        prevComments.filter((comment) => comment.id !== commentId),
+      )
+    } catch (error) {
+      console.error('댓글을 삭제하는 데 실패했습니다:', error)
     }
   }
 
@@ -166,7 +177,9 @@ const ModalTask = ({
         </div>
       </div>
       <CommentForm />
-      {comments?.map((comment) => <Comment key={comment.id} {...comment} />)}
+      {comments?.map((comment) => (
+        <Comment key={comment.id} {...comment} onDelete={DeleteComments} />
+      ))}
       <div ref={observeRef} />
     </div>
   )

--- a/src/components/common/modal/modal-task/index.tsx
+++ b/src/components/common/modal/modal-task/index.tsx
@@ -6,7 +6,7 @@ import BAR_ICON from '@/public/icons/bar.svg'
 import CLOSE_ICON from '@/public/icons/close.svg'
 import POPOVER_ICON from '@/public/icons/popover.svg'
 import useIntersectionObserver from '@/src/hooks/useInterSectionObserver'
-import { GetTaskCards } from '@/src/types/dashboard.interface'
+import { CommentsType } from '@/src/types/dashboard.interface'
 
 import Comment from './comment'
 import CommentForm from './comment-form/input'
@@ -42,7 +42,7 @@ const ModalTask = ({
   const modalStatus = useContext(ModalContext)
   const observeRef = useRef<HTMLDivElement>(null)
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
-  const [comments, setComments] = useState<TaskCardDataType[]>([])
+  const [comments, setComments] = useState<CommentsType[]>([])
   const [nextCursorId, setNextCursorId] = useState<number | null>(null)
   const { observe, isScrolled } = useIntersectionObserver()
 
@@ -52,14 +52,12 @@ const ModalTask = ({
   const fetchComments = async (firstFetch: boolean = false) => {
     if (cardId) {
       try {
-        const {
-          data: comments,
-          nextCursorId: fetchNextCursorId,
-        }: GetTaskCards = await getComments(
-          cardId,
-          firstFetch ? null : nextCursorId,
-          firstFetch,
-        )
+        const { data: comments, nextCursorId: fetchNextCursorId } =
+          await getComments(
+            cardId,
+            firstFetch ? null : nextCursorId,
+            firstFetch,
+          )
         setComments((prev) => (firstFetch ? comments : [...prev, ...comments]))
         setNextCursorId(fetchNextCursorId)
       } catch (error) {
@@ -68,7 +66,7 @@ const ModalTask = ({
     }
   }
 
-  const DeleteComments = async (commentId) => {
+  const DeleteComments = async (commentId: number) => {
     try {
       await deleteComment(commentId)
       setComments((prevComments) =>

--- a/src/components/common/modal/modal-task/index.tsx
+++ b/src/components/common/modal/modal-task/index.tsx
@@ -1,9 +1,12 @@
 import Image from 'next/image'
-import { useContext, useState } from 'react'
+import { useContext, useEffect, useRef, useState } from 'react'
 
+import { getComments } from '@/pages/api/comments'
 import BAR_ICON from '@/public/icons/bar.svg'
 import CLOSE_ICON from '@/public/icons/close.svg'
 import POPOVER_ICON from '@/public/icons/popover.svg'
+import useIntersectionObserver from '@/src/hooks/useInterSectionObserver'
+import { GetTaskCards } from '@/src/types/dashboard.interface'
 
 import Comment from './comment'
 import CommentForm from './comment-form/input'
@@ -13,19 +16,8 @@ import ProgressChip from '../../chip/progress-chip'
 import TagChip from '../../chip/tag-chip'
 import ManagerProfile from '../../manager-profile'
 
-const dummyComment = {
-  id: 1,
-  content: '안녕안녕',
-  createdAt: '2024-04-04',
-  author: {
-    profileImageUrl:
-      'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/taskify/profile_image/4-6_1710_1713772649563.png',
-    nickname: '안연아',
-  },
-}
-// 임시로 더미 데이터를 만들어놨습니다. 실제 모달 적용할 때 이 부분 말고 실제 데이터를 입력 해야합니다!
-
 interface ModalTaskProps {
+  cardId: number
   title: string
   description: string
   tags: string[]
@@ -39,6 +31,7 @@ interface ModalTaskProps {
 }
 
 const ModalTask = ({
+  cardId,
   title,
   description,
   tags,
@@ -47,11 +40,49 @@ const ModalTask = ({
   imageUrl,
 }: ModalTaskProps) => {
   const modalStatus = useContext(ModalContext)
+  const observeRef = useRef<HTMLDivElement>(null)
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
+  const [comments, setComments] = useState<TaskCardDataType[]>([])
+  const [nextCursorId, setNextCursorId] = useState<number | null>(null)
+  const { observe, isScrolled } = useIntersectionObserver()
 
   const handleClose = () => {
     modalStatus.setIsOpen.call(null, false)
   }
+  const fetchComments = async (firstFetch: boolean = false) => {
+    if (cardId) {
+      try {
+        const {
+          data: comments,
+          nextCursorId: fetchNextCursorId,
+        }: GetTaskCards = await getComments(
+          cardId,
+          firstFetch ? null : nextCursorId,
+          firstFetch,
+        )
+        setComments((prev) => (firstFetch ? comments : [...prev, ...comments]))
+        setNextCursorId(fetchNextCursorId)
+      } catch (error) {
+        console.error('댓글을 불러오는 데 실패했습니다.:', error)
+      }
+    }
+  }
+
+  useEffect(() => {
+    fetchComments(true)
+  }, [cardId])
+
+  useEffect(() => {
+    if (comments.length >= 3 && observeRef.current) {
+      observe(observeRef.current)
+    }
+  }, [observe, comments])
+
+  useEffect(() => {
+    if (isScrolled && nextCursorId) {
+      fetchComments()
+    }
+  }, [isScrolled, nextCursorId])
 
   const togglePopover = () => {
     setIsPopoverOpen((prev) => !prev)
@@ -109,13 +140,15 @@ const ModalTask = ({
             </div>
           </div>
           <p className={S.text}>{description}</p>
-          <Image
-            src={imageUrl}
-            alt="임시 사진"
-            width={450}
-            height={262}
-            className={S.contentImg}
-          />
+          {imageUrl && (
+            <Image
+              src={imageUrl}
+              alt="임시 사진"
+              width={450}
+              height={262}
+              className={S.contentImg}
+            />
+          )}
         </div>
         <div className={S.taskDetails}>
           <div className={S.assignee}>
@@ -133,13 +166,8 @@ const ModalTask = ({
         </div>
       </div>
       <CommentForm />
-      <Comment
-        id={dummyComment.id}
-        content={dummyComment.content}
-        createdAt={dummyComment.createdAt}
-        author={dummyComment.author}
-      />
-      {/* 지금은 Comment 컴포넌트를 이렇게 구현했지만 이 부분 댓글 목록 조회해서 무한 스크롤 구현해야 합니다.  */}
+      {comments?.map((comment) => <Comment key={comment.id} {...comment} />)}
+      <div ref={observeRef} />
     </div>
   )
 }

--- a/src/components/dashboard/column/index.tsx
+++ b/src/components/dashboard/column/index.tsx
@@ -62,7 +62,7 @@ const Column = ({ id: columnId, title, dashboardId }: ColumnDataType) => {
       />
       <div className={S.taskWrapper}>
         <DashboardButton type="add" onClick={handleClick} />
-        {taskCards.map((taskCard) => (
+        {taskCards?.map((taskCard) => (
           <TaskCard key={taskCard.id} {...taskCard} />
         ))}
       </div>

--- a/src/components/dashboard/column/task-card/TaskCard.module.scss
+++ b/src/components/dashboard/column/task-card/TaskCard.module.scss
@@ -10,6 +10,7 @@
   border: 0.1rem solid $color-gray-300;
   border-radius: 0.6rem;
   background-color: $color-white;
+  cursor: pointer;
 
   @include tablet {
     flex-direction: row;

--- a/src/components/dashboard/column/task-card/index.tsx
+++ b/src/components/dashboard/column/task-card/index.tsx
@@ -1,5 +1,8 @@
 import Image from 'next/image'
+import { useState } from 'react'
 
+import Modal from '@/src/components/common/modal'
+import ModalTask from '@/src/components/common/modal/modal-task'
 import { TaskCardDataType } from '@/src/types/dashboard.interface'
 
 import S from './TaskCard.module.scss'
@@ -11,30 +14,57 @@ import TaskCardTag from '../task-card-tag'
 //TODO: 아이콘 navbar에서 받을 것
 //TODO: 이미지 데이터
 
-const TaskCard = ({ title, dueDate, imageUrl, tags }: TaskCardDataType) => {
+const TaskCard = ({
+  title,
+  description,
+  tags,
+  dueDate,
+  assignee,
+  imageUrl,
+}: TaskCardDataType) => {
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
+  const handleClick = () => {
+    setIsModalOpen(true)
+  }
+
   return (
-    <div className={S.container}>
-      <div className={S.imageWrapper}>
-        <Image
-          className={S.cardImage}
-          src={imageUrl}
-          width={274}
-          height={160}
-          layout="responsive"
-          alt="카드 이미지"
-        />
-      </div>
-      <div className={S.content}>
-        <h2 className={S.cardTitle}>{title}</h2>
-        <div className={S.wrapper}>
-          <TaskCardTag tagType="프로젝트" />
-          <div className={S.cardBottom}>
-            <TaskCardDate dueDate={dueDate} />
-            <div>아이콘</div>
+    <>
+      <div className={S.container} onClick={handleClick}>
+        <div className={S.imageWrapper}>
+          <Image
+            className={S.cardImage}
+            src={imageUrl}
+            width={274}
+            height={160}
+            layout="responsive"
+            alt="카드 이미지"
+          />
+        </div>
+        <div className={S.content}>
+          <h2 className={S.cardTitle}>{title}</h2>
+          <div className={S.wrapper}>
+            <TaskCardTag tagType="프로젝트" />
+            <div className={S.cardBottom}>
+              <TaskCardDate dueDate={dueDate} />
+              <div>아이콘</div>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+      {isModalOpen && (
+        <Modal setIsOpen={setIsModalOpen}>
+          <ModalTask
+            title={title}
+            dueDate={dueDate}
+            assignee={assignee}
+            imageUrl={imageUrl}
+            tags={tags}
+            description={description}
+          />
+        </Modal>
+      )}
+    </>
   )
 }
 

--- a/src/components/dashboard/column/task-card/index.tsx
+++ b/src/components/dashboard/column/task-card/index.tsx
@@ -15,6 +15,7 @@ import TaskCardTag from '../task-card-tag'
 //TODO: 이미지 데이터
 
 const TaskCard = ({
+  id,
   title,
   description,
   tags,
@@ -55,6 +56,7 @@ const TaskCard = ({
       {isModalOpen && (
         <Modal setIsOpen={setIsModalOpen}>
           <ModalTask
+            cardId={id}
             title={title}
             dueDate={dueDate}
             assignee={assignee}

--- a/src/components/dashboard/column/task-card/index.tsx
+++ b/src/components/dashboard/column/task-card/index.tsx
@@ -1,11 +1,10 @@
 import Image from 'next/image'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import Modal from '@/src/components/common/modal'
 import ModalEdittodo from '@/src/components/common/modal/modal-edittodo'
 import ModalTask from '@/src/components/common/modal/modal-task'
 import { EMPTY_DUEDATE } from '@/src/constants/date'
-import { TaskCardDataType } from '@/src/types/dashboard.interface'
 
 import S from './TaskCard.module.scss'
 import TaskCardDate from '../task-card-date'
@@ -25,10 +24,6 @@ const TaskCard = ({ columnId, taskCard }: TaskCardProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [cardData, setCardData] = useState(taskCard)
 
-  const handleClick = () => {
-    setIsModalOpen(true)
-  }
-
   return (
     <div className={S.container} onClick={() => setIsModalOpen(true)}>
       {isModalOpen && (
@@ -37,6 +32,19 @@ const TaskCard = ({ columnId, taskCard }: TaskCardProps) => {
             columnId={columnId}
             cardData={cardData}
             setCardData={setCardData}
+          />
+        </Modal>
+      )}
+      {isModalOpen && (
+        <Modal setIsOpen={setIsModalOpen}>
+          <ModalTask
+            cardId={cardData.id}
+            title={cardData.title}
+            dueDate={cardData.dueDate}
+            assignee={cardData.assignee}
+            imageUrl={cardData.imageUrl}
+            tags={cardData.tags}
+            description={cardData.description}
           />
         </Modal>
       )}

--- a/src/components/dashboard/column/task-card/index.tsx
+++ b/src/components/dashboard/column/task-card/index.tsx
@@ -26,7 +26,7 @@ const TaskCard = ({ columnId, taskCard }: TaskCardProps) => {
 
   return (
     <div className={S.container} onClick={() => setIsModalOpen(true)}>
-      {isModalOpen && (
+      {/* {isModalOpen && (
         <Modal setIsOpen={setIsModalOpen}>
           <ModalEdittodo
             columnId={columnId}
@@ -34,7 +34,7 @@ const TaskCard = ({ columnId, taskCard }: TaskCardProps) => {
             setCardData={setCardData}
           />
         </Modal>
-      )}
+      )} */}
       {isModalOpen && (
         <Modal setIsOpen={setIsModalOpen}>
           <ModalTask

--- a/src/types/dashboard.interface.ts
+++ b/src/types/dashboard.interface.ts
@@ -21,7 +21,12 @@ export interface TaskCardDataType {
   description: string
   dueDate: string
   imageUrl: string
-  tags?: string[]
+  tags: string[]
+  assignee: {
+    profileImageUrl: string
+    nickname: string
+    id: number
+  }
 }
 
 export type TaskCardDateType = {

--- a/src/types/dashboard.interface.ts
+++ b/src/types/dashboard.interface.ts
@@ -1,3 +1,17 @@
+export interface CommentsType {
+  author: {
+    id: number
+    nickname: string
+    profileImageUrl: string | null
+  }
+  cardId: number
+  content: string
+  id: number
+  createdAt: string
+  updatedAt: string
+  onDelete: (commentId: number) => void
+}
+
 export interface ColumnTitleType {
   columnName?: string
   newColumn?: string


### PR DESCRIPTION
## 🚀 주요 변경 사항

- 할일 카드 눌렀을 시 ModalTask 나타나도록 하였습니다.
- 댓글 불러오기, 삭제, 추가 기능 구현하였습니다.
- 댓글 무한스크롤 기능 구현하였습니다.

## 🖼️ 스크린샷

## 📝 기타 논의 사항

- 일단 스크롤이 되도록 ModalTask 전체 height 고정하였습니다.
- 모달이 2개 켜질 경우 모달이 닫히지 않는 현상이 있습니다.
- 현재 ModalTask도 닫히지 않는데 이 부분은 추가 작업 해서 pr 올리겠습니다.
- ModalEdit 이관 작업도 이후에 추가하겠습니다. (현재는 잠시 주석처리 해두었습니다.)