### PR TITLE
API 함수 분리, 할 일 생성 시 하루 이전 날짜로 등록되는 문제

### DIFF
--- a/pages/api/auth.ts
+++ b/pages/api/auth.ts
@@ -1,0 +1,17 @@
+import AXIOS from '@/lib/axios'
+
+/**
+ *
+ * @description 로그인 요청
+ * @param {email} string - 이메일
+ * @param {password} string - 비밀번호
+ * @returns accessToken
+ */
+export const fetchPostLogin = async (email: string, password: string) => {
+  const response = await AXIOS.post('/auth/login', {
+    email,
+    password,
+  })
+
+  return response.data.accessToken
+}

--- a/pages/api/users.ts
+++ b/pages/api/users.ts
@@ -2,6 +2,28 @@ import AXIOS from '@/lib/axios'
 
 /**
  *
+ * @description 회원가입 요청
+ * @param {email} string - 이메일
+ * @param {nickname} string - 닉네임
+ * @param {password} string - 비밀번호
+ * @returns accessToken
+ */
+export const fetchPostUser = async (
+  email: string,
+  nickname: string,
+  password: string,
+) => {
+  const response = await AXIOS.post('/users', {
+    email,
+    nickname,
+    password,
+  })
+
+  return response.status
+}
+
+/**
+ *
  * @description 내 정보 조회
  * @returns id, email, nickname, profileImageUrl, createdAt, updatedAt
  */

--- a/src/components/common/input/text/Text.module.scss
+++ b/src/components/common/input/text/Text.module.scss
@@ -16,6 +16,10 @@
     @include Input.input(45rem, 28.7rem);
   }
 
+  &.nickname {
+    @include Input.input(52rem, 35.1rem);
+  }
+
   &.newDash {
     @include Input.input(48.4rem, 28.7rem);
   }

--- a/src/components/dashboard/column/task-card/TaskCard.module.scss
+++ b/src/components/dashboard/column/task-card/TaskCard.module.scss
@@ -10,6 +10,7 @@
   border: 0.1rem solid $color-gray-300;
   border-radius: 0.6rem;
   background-color: $color-white;
+  cursor: pointer;
 
   @include tablet {
     flex-direction: row;

--- a/src/components/login-signup/form/login/index.tsx
+++ b/src/components/login-signup/form/login/index.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router'
 import { useState } from 'react'
 import { useForm, SubmitHandler } from 'react-hook-form'
 
-import AXIOS from '@/lib/axios'
+import { fetchPostLogin } from '@/pages/api/auth'
 import BasicButton from '@/src/components/common/button/basic'
 import Input from '@/src/components/common/input'
 import Modal from '@/src/components/common/modal'
@@ -25,12 +25,9 @@ const LogInForm = () => {
   const onSubmit: SubmitHandler<InputFormValues> = (data) => {
     if (data.email === '' || data.password === '') return
 
-    AXIOS.post('/auth/login', {
-      email: data.email,
-      password: data.password,
-    })
-      .then((res) => {
-        localStorage.setItem('accessToken', res.data.accessToken)
+    fetchPostLogin(data.email, data.password)
+      .then((accessToken) => {
+        localStorage.setItem('accessToken', accessToken)
         router.push('/mydashboard')
       })
       .catch(() => {

--- a/src/components/login-signup/form/login/index.tsx
+++ b/src/components/login-signup/form/login/index.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useForm, SubmitHandler } from 'react-hook-form'
 
 import { fetchPostLogin } from '@/pages/api/auth'
@@ -34,6 +34,14 @@ const LogInForm = () => {
         setIsModalOpen(true)
       })
   }
+
+  useEffect(() => {
+    const accessToken = localStorage.getItem('accessToken')
+
+    if (accessToken) {
+      router.push('/mydashboard')
+    }
+  }, [])
 
   return (
     <>

--- a/src/components/login-signup/form/signup/index.tsx
+++ b/src/components/login-signup/form/signup/index.tsx
@@ -67,6 +67,7 @@ const SignUpForm = () => {
           placeholder="닉네임을 입력해 주세요"
           error={errors.nickname}
           register={register}
+          size="large"
         />
         <label className={S.label}>비밀번호</label>
         <Input

--- a/src/components/login-signup/form/signup/index.tsx
+++ b/src/components/login-signup/form/signup/index.tsx
@@ -1,8 +1,7 @@
-import { useRouter } from 'next/router'
 import { useState } from 'react'
 import { useForm, SubmitHandler } from 'react-hook-form'
 
-import AXIOS from '@/lib/axios'
+import { fetchPostUser } from '@/pages/api/users'
 import BasicButton from '@/src/components/common/button/basic'
 import Input from '@/src/components/common/input'
 import Modal from '@/src/components/common/modal'
@@ -12,7 +11,6 @@ import { InputFormValues } from '@/src/types/input'
 import S from '../Form.module.scss'
 
 const SignUpForm = () => {
-  const router = useRouter()
   const [isChecked, setIsChecked] = useState(false)
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false)
   const [isErrorModalOpen, setIsErrorModalOpen] = useState(false)
@@ -27,11 +25,7 @@ const SignUpForm = () => {
   const onSubmit: SubmitHandler<InputFormValues> = (data) => {
     if (!isChecked || Object.keys(errors).length > 0) return
 
-    AXIOS.post('/users', {
-      email: data.email,
-      nickname: data.nickname,
-      password: data.password,
-    })
+    fetchPostUser(data.email, data.nickname, data.password)
       .then(() => {
         setIsSuccessModalOpen(true)
       })

--- a/src/components/login-signup/form/signup/index.tsx
+++ b/src/components/login-signup/form/signup/index.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
 import { useForm, SubmitHandler } from 'react-hook-form'
 
 import { fetchPostUser } from '@/pages/api/users'
@@ -11,6 +12,7 @@ import { InputFormValues } from '@/src/types/input'
 import S from '../Form.module.scss'
 
 const SignUpForm = () => {
+  const router = useRouter()
   const [isChecked, setIsChecked] = useState(false)
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false)
   const [isErrorModalOpen, setIsErrorModalOpen] = useState(false)
@@ -33,6 +35,14 @@ const SignUpForm = () => {
         setIsErrorModalOpen(true)
       })
   }
+
+  useEffect(() => {
+    const accessToken = localStorage.getItem('accessToken')
+
+    if (accessToken) {
+      router.push('/mydashboard')
+    }
+  }, [])
 
   return (
     <>

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,6 +1,13 @@
-export const formatDate = (date: string | Date): string => {
-  const parsedDate = new Date(date)
-  const formattedDate = parsedDate.toISOString().slice(0, 10)
-  const formattedTime = parsedDate.toTimeString().slice(0, 5)
-  return `${formattedDate} ${formattedTime}`
+export const formatDate = (dateString: string | Date): string => {
+  const date = new Date(dateString)
+
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  const hours = String(date.getHours()).padStart(2, '0')
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+
+  const formattedDate = `${year}-${month}-${day} ${hours}:${minutes}`
+
+  return formattedDate
 }


### PR DESCRIPTION
## 🚀 주요 변경 사항

### 1. 회원가입, 로그인 api 함수 분리 #115 

- 기존에 개별 폼의 submit 함수에서 직접 작성한 부분을 api 폴더 내에 별도의 함수로 분리했습니다

### 2. 로그인 유저의 로그인, 회원가입 페이지 접근

- 나의 대시보드 페이지로 이동시키는 로직을 추가하였습니다

### 3. 할 일 생성 시 하루 이전 날짜로 등록되는 문제 해결 #123 

- formatDate 함수 로직을 수정했습니다
- 기존 로직에서 사용되던 ISOString은 영국 표준시로 변환시켜주기 때문에 한국 시간으로 등록되면 영국 시간으로 바뀌는 문제였습니다
- 별도의 날짜 변환 메서드없이 문자열을 가공하는 방식으로 수정했습니다


## 🖼️ 스크린샷

## 📝 기타 논의 사항
