### PR TITLE
계정 관리 페이지 UI 수정

### DIFF
--- a/src/components/common/modal/modal-alert/ModalAlert.module.scss
+++ b/src/components/common/modal/modal-alert/ModalAlert.module.scss
@@ -2,15 +2,15 @@
 @import '@/src/styles/global.scss';
 
 .container {
-  @include Modal.modal(48.4rem, 19.4rem, 27.1rem, 16.4rem);
+  @include Modal.modal(54rem, 25rem, 32.7rem, 22rem);
   position: relative;
 
   display: flex;
   justify-content: center;
-  padding-top: 8rem;
+  padding-top: 10.8rem;
 
   @include mobile {
-    padding-top: 5.3rem;
+    padding-top: 8.1rem;
   }
 }
 
@@ -28,6 +28,6 @@
   right: 2.8rem;
 
   @include mobile {
-    left: 6.6rem;
+    left: 9.5rem;
   }
 }

--- a/src/components/mypage/password/index.tsx
+++ b/src/components/mypage/password/index.tsx
@@ -94,11 +94,11 @@ const Password = () => {
               size="small"
               color="purple"
               isDisabled={
-                watch('password') === '' ||
-                watch('newPassword') === '' ||
-                watch('newPasswordCheck') === ''
-                  ? true
-                  : false
+                watch('password') !== '' &&
+                watch('newPassword') !== '' &&
+                watch('newPasswordCheck') !== ''
+                  ? false
+                  : true
               }
             >
               변경

--- a/src/components/mypage/profile-form/ProfileForm.module.scss
+++ b/src/components/mypage/profile-form/ProfileForm.module.scss
@@ -69,6 +69,10 @@
   }
 }
 
+.email {
+  cursor: not-allowed;
+}
+
 .button {
   display: flex;
   justify-content: flex-end;

--- a/src/components/mypage/profile-form/index.tsx
+++ b/src/components/mypage/profile-form/index.tsx
@@ -85,12 +85,12 @@ const ProfileForm = () => {
             type="text"
             disabled={true}
             placeholder={userData?.email}
-            className={S.textInput}
+            className={`${S.textInput} ${S.email}`}
           />
           <label className={S.title}>닉네임</label>
           <Input
             inputType="newNickname"
-            placeholder=""
+            placeholder={userData?.nickname}
             error={errors.newNickname}
             register={register}
             currentNickname={userData?.nickname}


### PR DESCRIPTION
## 🚀 주요 변경 사항

- 오늘 멘토링 시간에 계정 관리 페이지에 관해 ui 부분을 수정하였습니다. 
- 프로필에서 닉네임 input 유저의 기존 닉네임으로 placeholder 값을 주었습니다.
- 프로필에서 이메일 cursor : not-allowed로 지정하였습니다. 
- 비밀번호 변경 컴포넌트에서 아무값이 없을 떄도 변경 버튼이 비활성화 되도록 수정하였습니다. 
- 비밀번호 변경 오류 시 나오는 모달 ui를 피그마 시안에 맞게 수정하였습니다. 

## 🖼️ 스크린샷
![image](https://github.com/WhatToDo6/WhatToDo/assets/129318957/e3e38da1-f873-452e-acac-835e6b84ded9)
![image](https://github.com/WhatToDo6/WhatToDo/assets/129318957/6083c11e-8e2d-40f7-bc04-4dbd8dd6d1b7)
![image](https://github.com/WhatToDo6/WhatToDo/assets/129318957/808a2871-7fca-458e-a51d-94b227a5d5a9)

## 📝 기타 논의 사항
