### PR TITLE
Toast 기능 일부 적용

### DIFF
--- a/pages/dashboards/[id]/edit/index.tsx
+++ b/pages/dashboards/[id]/edit/index.tsx
@@ -9,6 +9,8 @@ import DashboardButton from '@/src/components/dashboard/dashboard-button'
 import DashboardEditor from '@/src/components/dashboard/editor'
 import InviteListEmail from '@/src/components/dashboard/invited-list/email'
 import InviteListMember from '@/src/components/dashboard/invited-list/member'
+import Toast from '@/src/components/toast'
+import { ToastProvider } from '@/src/context/toast'
 
 import S from './DashboardIdEdit.module.scss'
 
@@ -48,17 +50,23 @@ const DashboardIdEdit = ({ id }: DashboardIdEditProps) => {
   }
 
   return (
-    <Layout>
-      <div className={S.container}>
-        <BackButton />
-        <DashboardEditor dashboardId={id} />
-        <InviteListMember />
-        <InviteListEmail dashboardId={id} />
-        <div className={S.buttonBox}>
-          <DashboardButton type="deleteDashboard" onClick={handleButtonClick} />
+    <ToastProvider>
+      <Layout>
+        <div className={S.container}>
+          <BackButton />
+          <DashboardEditor dashboardId={id} />
+          <InviteListMember />
+          <InviteListEmail dashboardId={id} />
+          <div className={S.buttonBox}>
+            <DashboardButton
+              type="deleteDashboard"
+              onClick={handleButtonClick}
+            />
+          </div>
         </div>
-      </div>
-    </Layout>
+      </Layout>
+      <Toast />
+    </ToastProvider>
   )
 }
 

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -1,11 +1,16 @@
 import Layout from '@/src/components/common/layout'
 import Content from '@/src/components/mypage/content'
+import Toast from '@/src/components/toast'
+import { ToastProvider } from '@/src/context/toast'
 
 const MyPage = () => {
   return (
-    <Layout>
-      <Content />
-    </Layout>
+    <ToastProvider>
+      <Layout>
+        <Content />
+      </Layout>
+      <Toast />
+    </ToastProvider>
   )
 }
 

--- a/src/components/dashboard/editor/index.tsx
+++ b/src/components/dashboard/editor/index.tsx
@@ -3,6 +3,7 @@ import { useForm } from 'react-hook-form'
 
 import { fetchPutDashboardEdit } from '@/pages/api/dashboards'
 import { DashboardsContext } from '@/src/context/dashboards'
+import { useToast } from '@/src/context/toast'
 import { InputFormValues } from '@/src/types/input'
 import { EditDahsboardParamType } from '@/src/types/mydashboard'
 
@@ -25,6 +26,7 @@ function DashboardEditor({ dashboardId }: DashboardEditorProps) {
     reset,
   } = useForm<InputFormValues>({ mode: 'onBlur' })
   const [selectedColor, setSelectedColor] = useState(initialColor)
+  const { addToast } = useToast()
 
   const { dashboardDetail, setDashboardDetail, editSideMenuDashboards } =
     useContext(DashboardsContext)
@@ -36,6 +38,7 @@ function DashboardEditor({ dashboardId }: DashboardEditorProps) {
       setSelectedColor(initialColor)
       setDashboardDetail(dashboard)
       editSideMenuDashboards(dashboard)
+      addToast('대시보드가 성공적으로 업데이트 되었습니다', 'success')
     } catch (err) {
       console.error(err)
     }

--- a/src/components/dashboard/invited-list/email/index.tsx
+++ b/src/components/dashboard/invited-list/email/index.tsx
@@ -7,6 +7,7 @@ import BorderButton from '@/src/components/common/button/border'
 import Modal from '@/src/components/common/modal'
 import ModalDashBoard from '@/src/components/common/modal/modal-dashboard'
 import { InviteeEmailContext } from '@/src/context/inviteeEmail'
+import { useToast } from '@/src/context/toast'
 import { InviteDashboardParamType } from '@/src/types/mydashboard'
 
 import S from './InviteListEmail.module.scss'
@@ -29,6 +30,7 @@ function InviteListEmail({ dashboardId }: InviteListEmailProps) {
   } = useContext(InviteeEmailContext)
 
   const [isModalOpen, setIsModalOpen] = useState(false)
+  const { addToast } = useToast()
 
   const handleModalClick = () => {
     setIsModalOpen(true)
@@ -38,6 +40,7 @@ function InviteListEmail({ dashboardId }: InviteListEmailProps) {
     try {
       await fetchPostInviteDashboard(data, dashboardId)
       handleCreate()
+      addToast('초대가 완료되었습니다.', 'success')
     } catch (err) {
       console.error(err)
     }

--- a/src/components/mypage/password/index.tsx
+++ b/src/components/mypage/password/index.tsx
@@ -6,12 +6,14 @@ import BorderButton from '@/src/components/common/button/border'
 import Input from '@/src/components/common/input'
 import Modal from '@/src/components/common/modal'
 import ModalAlert from '@/src/components/common/modal/modal-alert'
+import { useToast } from '@/src/context/toast'
 import { InputFormValues } from '@/src/types/input'
 
 import S from './Password.module.scss'
 
 const Password = () => {
   const [isModalOpen, setIsModalOpen] = useState(false)
+  const { addToast } = useToast()
 
   const {
     register,
@@ -36,9 +38,13 @@ const Password = () => {
             Authorization: `Bearer ${accessToken}`,
           },
         },
-      ).catch(() => {
-        setIsModalOpen(true)
-      })
+      )
+        .then(() => {
+          addToast('비밀번호가 성공적으로 업데이트 되었습니다.', 'success')
+        })
+        .catch(() => {
+          setIsModalOpen(true)
+        })
     }
     reset({
       password: '',

--- a/src/components/mypage/profile-form/index.tsx
+++ b/src/components/mypage/profile-form/index.tsx
@@ -76,7 +76,7 @@ const ProfileForm = () => {
       <div className={S.content}>
         <div className={S.imgContainer}>
           <InputProfileImage
-            profileImageUrl=""
+            profileImageUrl={uploadedImageUrl}
             handleImageChange={(event) =>
               handleImageChange(event, setUploadedImageUrl)
             }

--- a/src/components/mypage/profile-form/index.tsx
+++ b/src/components/mypage/profile-form/index.tsx
@@ -5,6 +5,7 @@ import AXIOS from '@/lib/axios'
 import { handleImageChange } from '@/pages/api/imageUpload'
 import BorderButton from '@/src/components/common/button/border'
 import Input from '@/src/components/common/input'
+import { useToast } from '@/src/context/toast'
 import { useUser } from '@/src/context/users'
 import { InputFormValues } from '@/src/types/input'
 
@@ -18,6 +19,7 @@ interface ProfileUpdateProps {
 
 const ProfileForm = () => {
   const { userData, setUserData } = useUser()
+  const { addToast } = useToast()
   const [uploadedImageUrl, setUploadedImageUrl] = useState('')
 
   useEffect(() => {
@@ -57,6 +59,7 @@ const ProfileForm = () => {
                 nickname: res.data.nickname,
               }
             })
+            addToast('프로필이 성공적으로 업데이트 되었습니다.', 'success')
           })
           .catch((err) => {
             console.error(err.response.data.message)
@@ -73,7 +76,7 @@ const ProfileForm = () => {
       <div className={S.content}>
         <div className={S.imgContainer}>
           <InputProfileImage
-            profileImageUrl={uploadedImageUrl}
+            profileImageUrl=""
             handleImageChange={(event) =>
               handleImageChange(event, setUploadedImageUrl)
             }

--- a/src/components/toast/Toast.module.scss
+++ b/src/components/toast/Toast.module.scss
@@ -1,0 +1,83 @@
+@import '@/src/styles/global.scss';
+
+@keyframes slideInRight {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes slideOutRight {
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+}
+
+.toastContainer {
+  position: fixed;
+  top: 10rem;
+  right: 3rem;
+  z-index: 1000;
+}
+
+.toast {
+  width: 50rem;
+  height: 8rem;
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  margin-bottom: 1rem;
+  padding: 3rem 2rem;
+  border-radius: 0.8rem;
+  box-shadow: 0 0.4rem 2rem 0 rgba(0, 0, 0, 0.08);
+  background-color: $color-white;
+  animation: slideInRight 0.5s ease-out forwards;
+}
+
+.text {
+  color: $color-black-200;
+  @include font-style(2rem, 500, normal);
+}
+
+.imgSuccess {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 2rem;
+  height: 2rem;
+  background-color: $color-green;
+  border-radius: 100%;
+}
+
+.imgError {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 2rem;
+  height: 2rem;
+  background-color: $color-red;
+  border-radius: 100%;
+  color: $color-white;
+  @include font-style(1.5rem, normal, normal);
+}
+
+.toastHide {
+  animation: slideOutRight 0.5s ease-out forwards;
+}
+
+.toast-success {
+  border: 0.1rem solid $color-green;
+}
+
+.toast-error {
+  border: 0.1rem solid $color-red;
+}

--- a/src/components/toast/index.tsx
+++ b/src/components/toast/index.tsx
@@ -1,0 +1,61 @@
+import Image from 'next/image'
+import { useEffect } from 'react'
+
+import SUCCESS_IMG from '@/public/icons/check.svg'
+import { useToast } from '@/src/context/toast'
+
+import S from './Toast.module.scss'
+
+type Timeout = NodeJS.Timeout
+
+const Toast = () => {
+  const { toasts, removeToast } = useToast()
+
+  useEffect(() => {
+    const timeouts: { hide: Timeout; remove: Timeout }[] = toasts.map(
+      (toast) => {
+        const hideTimeout: Timeout = setTimeout(() => {
+          const element = document.getElementById(toast.id.toString())
+          if (element) {
+            element.classList.add(S.toastHide)
+          }
+        }, 2500)
+
+        const removeTimeout: Timeout = setTimeout(() => {
+          removeToast(toast.id)
+        }, 3000)
+
+        return { hide: hideTimeout, remove: removeTimeout }
+      },
+    )
+
+    return () => {
+      timeouts.forEach((timeout) => {
+        clearTimeout(timeout.hide)
+        clearTimeout(timeout.remove)
+      })
+    }
+  }, [toasts, removeToast])
+
+  return (
+    <div className={S.toastContainer}>
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          id={toast.id.toString()}
+          className={`${S.toast} ${S[`toast-${toast.type}`]}`}
+        >
+          {toast.type === 'success' && (
+            <div className={S.imgSuccess}>
+              <Image src={SUCCESS_IMG} alt="성공" width={18} height={18} />
+            </div>
+          )}
+          {toast.type === 'error' && <div className={S.imgError}>!</div>}
+          <p className={S.text}>{toast.message}</p>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default Toast

--- a/src/context/toast.tsx
+++ b/src/context/toast.tsx
@@ -1,0 +1,43 @@
+import { createContext, useContext, useState } from 'react'
+
+import { ChildrenProps } from '../types/commonType'
+
+interface Toast {
+  id: number
+  message: string
+  type: 'success' | 'error'
+}
+
+interface ToastContextType {
+  toasts: Toast[]
+  addToast: (message: string, type: Toast['type']) => void
+  removeToast: (id: number) => void
+}
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined)
+
+export const useToast = () => {
+  const context = useContext(ToastContext)
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider')
+  }
+  return context
+}
+
+export const ToastProvider = ({ children }: ChildrenProps) => {
+  const [toasts, setToasts] = useState<Toast[]>([])
+  const addToast = (message: string, type: Toast['type']) => {
+    const id = new Date().getTime()
+
+    setToasts([...toasts, { id, message, type }])
+  }
+  const removeToast = (id: number) => {
+    setToasts(toasts.filter((toast) => toast.id !== id))
+  }
+
+  return (
+    <ToastContext.Provider value={{ toasts, addToast, removeToast }}>
+      {children}
+    </ToastContext.Provider>
+  )
+}


### PR DESCRIPTION
## 🚀 주요 변경 사항

- 계정관리 페이지, 대시보드 수정 페이지에 toast를 적용하였습니다. 

## 🖼️ 스크린샷
- 프로필 저장 시 토스트
![localhost_3000_mypage - Chrome 2024-04-25 21-04-45](https://github.com/WhatToDo6/WhatToDo/assets/129318957/2b351167-c745-428d-9894-00c0b1cdc17b)
 
- 비밀번호 변경 시 토스트
![localhost_3000_mypage - Chrome 2024-04-25 21-05-00](https://github.com/WhatToDo6/WhatToDo/assets/129318957/0716111b-bf3d-4b56-88c3-2f8fa2c42527)

- 대시보드 정보 변경 시 토스트
![localhost_3000_dashboards_7092_edit - Chrome 2024-04-25 21-04-08](https://github.com/WhatToDo6/WhatToDo/assets/129318957/9aa80291-d6aa-415b-b1f4-5f0c6243b7c0)


- 대시보드 초대하기 모달에서 초대 후 토스트
![localhost_3000_dashboards_7092_edit - Chrome 2024-04-25 21-04-25](https://github.com/WhatToDo6/WhatToDo/assets/129318957/bee7d8ef-d0df-46ae-a6f1-1ffc837478ad)



## 📝 기타 논의 사항
- 토스트 안 문구들 어떤가요?
- 관리자에 error 토스트를 주려고 했는데 아예 버튼을 비활성화 해서 이를 어떻게 하면 좋을지 다시 논의해봐야할 것 같습니다.
- 토스트가 생성된 차례대로 사라져야 하는데 지금 토스트가 많아지면 맨 마지막에 생성된 걸 기준으로 한번에 사라집니다. 이는 곧 수정할 예정입니다. 