### PR TITLE
card이미지가 null값일 때 처리, 댓글 빈 내용일 때 비활성화, 아이콘 taskCard연결

### DIFF
--- a/src/components/common/manager-profile/index.tsx
+++ b/src/components/common/manager-profile/index.tsx
@@ -8,8 +8,8 @@ import S from './ManagerProfile.module.scss'
 
 interface ManagerProfileProps {
   type: 'dropdown' | 'dashboardHeader' | 'card'
-  profileImageUrl: string | null
-  nickname: string
+  profileImageUrl: string | null | undefined
+  nickname?: string
   showPopover?: boolean
 }
 

--- a/src/components/common/modal/modal-task/comment-form/index.tsx
+++ b/src/components/common/modal/modal-task/comment-form/index.tsx
@@ -45,7 +45,12 @@ const CommentForm = ({ setComments, cardId, columnId }: CommentFormProps) => {
         onChange={(e) => setInputText(e.target.value)}
       />
       <div className={S.button}>
-        <BorderButton size="change" color="white" onClick={handleClick}>
+        <BorderButton
+          size="change"
+          color="white"
+          onClick={handleClick}
+          isDisabled={!inputText.trim()}
+        >
           입력
         </BorderButton>
       </div>

--- a/src/components/common/modal/modal-task/index.tsx
+++ b/src/components/common/modal/modal-task/index.tsx
@@ -182,7 +182,7 @@ const ModalTask = ({
           {imageUrl && (
             <Image
               src={imageUrl}
-              alt="임시 사진"
+              alt="할일 카드 이미지"
               width={450}
               height={262}
               className={S.contentImg}

--- a/src/components/dashboard/column/task-card/TaskCard.module.scss
+++ b/src/components/dashboard/column/task-card/TaskCard.module.scss
@@ -38,6 +38,10 @@
     width: 100%;
     height: auto;
   }
+
+  &.hidden {
+    display: none;
+  }
 }
 
 .content {

--- a/src/components/dashboard/column/task-card/TaskCard.module.scss
+++ b/src/components/dashboard/column/task-card/TaskCard.module.scss
@@ -63,15 +63,18 @@
 
   @include tablet {
     flex-direction: row;
+    align-items: center;
   }
 
   @include mobile {
     flex-direction: column;
+    align-items: normal;
   }
 }
 
 .tag {
   display: flex;
+  height: fit-content;
   gap: 0.6rem;
 }
 

--- a/src/components/dashboard/column/task-card/index.tsx
+++ b/src/components/dashboard/column/task-card/index.tsx
@@ -2,9 +2,11 @@ import Image from 'next/image'
 import { useState } from 'react'
 
 import TagChip from '@/src/components/common/chip/tag-chip'
+import ManagerProfile from '@/src/components/common/manager-profile'
 import Modal from '@/src/components/common/modal'
 import ModalTask from '@/src/components/common/modal/modal-task'
 import { EMPTY_DUEDATE } from '@/src/constants/date'
+import { useUser } from '@/src/context/users'
 import { TaskCardDataType } from '@/src/types/dashboard.interface'
 
 import S from './TaskCard.module.scss'
@@ -25,6 +27,7 @@ const TaskCard = ({
 }: TaskCardProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [cardData, setCardData] = useState<TaskCardDataType>(taskCard)
+  const { userData } = useUser()
 
   return (
     <>
@@ -57,7 +60,12 @@ const TaskCard = ({
               >
                 <TaskCardDate dueDate={cardData.dueDate} />
               </div>
-              <div>아이콘</div>
+              <div>
+                <ManagerProfile
+                  profileImageUrl={userData?.profileImageUrl}
+                  type="card"
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/dashboard/column/task-card/index.tsx
+++ b/src/components/dashboard/column/task-card/index.tsx
@@ -29,7 +29,9 @@ const TaskCard = ({
   return (
     <>
       <div className={S.container} onClick={() => setIsModalOpen(true)}>
-        <div className={S.imageWrapper}>
+        <div
+          className={`${S.imageWrapper} ${!cardData.imageUrl ? S.hidden : ''}`}
+        >
           {cardData.imageUrl && (
             <Image
               className={S.cardImage}


### PR DESCRIPTION
## 🚀 주요 변경 사항

### card이미지가 null값일 때 처리
- card이미지에 아무 이미지도 넣지 않았을 때 null에러가 나는 것을 해결했습니다
- card이미지에 이미지를 비워서 제출하면 비워진 채로 렌더링 되도록 css 수정 했습니다.

### 댓글이 빈 내용일 때, 비활성화
- textarea의 value값이 없을 때 버튼 비활성화 시켰습니다.

### taskCards에 아이콘 연결했습니다.
- ManagerProfile컴포넌트를 연결하여 아이콘 활성화 시켰습니다.

## 🖼️ 스크린샷

![image](https://github.com/WhatToDo6/WhatToDo/assets/108844881/cb6a261a-2473-413f-83f5-d4d78e284a4a)

![image](https://github.com/WhatToDo6/WhatToDo/assets/108844881/9db0e2f1-89fd-497c-bb43-b81747393a1b)

![image](https://github.com/WhatToDo6/WhatToDo/assets/108844881/b91943bc-3933-4b3a-aa76-df67036fbf18)


## 📝 기타 논의 사항

- 비활성화 버튼 디자인이 조금 고민됩니다.