### PR TITLE
대시보드 수정 페이지 삭제,변경,취소 하기전 확인용 모달 적용 완료

### DIFF
--- a/pages/api/members.ts
+++ b/pages/api/members.ts
@@ -21,3 +21,13 @@ export const fetchGetDashboardMemberList = async <U>(
   } = response
   return { data: members, totalCount }
 }
+
+//대시보드 멤버 삭제
+export const fetchDeleteDashboardMember = async (memberId: number) => {
+  const token = localStorage.getItem('accessToken')
+  await AXIOS.delete(`/members/${memberId}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  })
+}

--- a/pages/dashboards/[id]/edit/index.tsx
+++ b/pages/dashboards/[id]/edit/index.tsx
@@ -1,16 +1,17 @@
 import { GetStaticPropsContext } from 'next'
 
 import { useRouter } from 'next/router'
+import { useState } from 'react'
 
 import { fetchDeleteDashboard } from '@/pages/api/dashboards'
 import BackButton from '@/src/components/common/back-button/BackButton'
 import Layout from '@/src/components/common/layout'
+import Modal from '@/src/components/common/modal'
+import ModalConfirm from '@/src/components/common/modal/modal-confirm'
 import DashboardButton from '@/src/components/dashboard/dashboard-button'
 import DashboardEditor from '@/src/components/dashboard/editor'
 import InviteListEmail from '@/src/components/dashboard/invited-list/email'
 import InviteListMember from '@/src/components/dashboard/invited-list/member'
-import Toast from '@/src/components/toast'
-import { ToastProvider } from '@/src/context/toast'
 
 import S from './DashboardIdEdit.module.scss'
 
@@ -35,6 +36,11 @@ interface DashboardIdEditProps {
 
 const DashboardIdEdit = ({ id }: DashboardIdEditProps) => {
   const router = useRouter()
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
+  const handleClick = () => {
+    setIsModalOpen(true)
+  }
 
   const deleteDashboard = async () => {
     try {
@@ -50,7 +56,17 @@ const DashboardIdEdit = ({ id }: DashboardIdEditProps) => {
   }
 
   return (
-    <ToastProvider>
+    <>
+      {isModalOpen && (
+        <Modal setIsOpen={setIsModalOpen}>
+          <ModalConfirm
+            content="대시보드를 삭제하시겠습니까?"
+            leftButtonText="취소"
+            rightButtonText="삭제"
+            onClick={handleButtonClick}
+          />
+        </Modal>
+      )}
       <Layout>
         <div className={S.container}>
           <BackButton />
@@ -58,15 +74,11 @@ const DashboardIdEdit = ({ id }: DashboardIdEditProps) => {
           <InviteListMember />
           <InviteListEmail dashboardId={id} />
           <div className={S.buttonBox}>
-            <DashboardButton
-              type="deleteDashboard"
-              onClick={handleButtonClick}
-            />
+            <DashboardButton type="deleteDashboard" onClick={handleClick} />
           </div>
         </div>
       </Layout>
-      <Toast />
-    </ToastProvider>
+    </>
   )
 }
 

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -1,16 +1,11 @@
 import Layout from '@/src/components/common/layout'
 import Content from '@/src/components/mypage/content'
-import Toast from '@/src/components/toast'
-import { ToastProvider } from '@/src/context/toast'
 
 const MyPage = () => {
   return (
-    <ToastProvider>
-      <Layout>
-        <Content />
-      </Layout>
-      <Toast />
-    </ToastProvider>
+    <Layout>
+      <Content />
+    </Layout>
   )
 }
 

--- a/src/components/common/layout/index.tsx
+++ b/src/components/common/layout/index.tsx
@@ -5,11 +5,13 @@ import SideMenu from '@/src/components/dashboard/side-menu'
 import DashboardsProvider from '@/src/context/dashboards'
 import InviteeEmailProvider from '@/src/context/inviteeEmail'
 import MembersProvider from '@/src/context/members'
+import { ToastProvider } from '@/src/context/toast'
 import UserProvider from '@/src/context/users'
 import { ChildrenProps } from '@/src/types/commonType'
 
 import S from './Layout.module.scss'
 import DashboardHeader from '../../dashboard/header'
+import Toast from '../../toast'
 
 type ContextType = ComponentType<ChildrenProps>
 
@@ -31,8 +33,9 @@ const Layout = ({ children }: ChildrenProps) => {
       contexts={[
         MembersProvider,
         InviteeEmailProvider,
-        DashboardsProvider,
         UserProvider,
+        DashboardsProvider,
+        ToastProvider,
       ]}
     >
       <div className={S.container}>
@@ -44,6 +47,7 @@ const Layout = ({ children }: ChildrenProps) => {
           <main className={S.children}>{children}</main>
         </div>
       </div>
+      <Toast />
     </AppProvider>
   )
 }

--- a/src/components/common/modal/modal-confirm/ModalConfirm.module.scss
+++ b/src/components/common/modal/modal-confirm/ModalConfirm.module.scss
@@ -1,0 +1,32 @@
+@use '.././Modal.module.scss' as Modal;
+@import '@/src/styles/global.scss';
+
+.container {
+  @include Modal.modal(54rem, 25rem, 32.7rem, 22rem);
+  position: relative;
+
+  display: flex;
+  justify-content: center;
+  padding-top: 8rem;
+
+  @include mobile {
+    padding-top: 5.3rem;
+  }
+}
+
+.content {
+  color: $color-black-200;
+  @include font-style(1.8rem, 500, normal);
+  @include mobile {
+    @include font-style(1.6rem, 500, normal);
+  }
+}
+
+.button {
+  position: absolute;
+  bottom: 2.8rem;
+  right: 2.8rem;
+  @include mobile {
+    left: 2.8rem;
+  }
+}

--- a/src/components/common/modal/modal-confirm/index.tsx
+++ b/src/components/common/modal/modal-confirm/index.tsx
@@ -1,0 +1,57 @@
+import { useContext } from 'react'
+
+import S from './ModalConfirm.module.scss'
+import { ModalContext } from '..'
+import OptionButton from '../../button/option'
+
+interface ModalConfirm {
+  content: string
+  leftButtonText: string
+  rightButtonText: string
+  onClick: () => void
+}
+
+/**
+ * @param content - 모달 내부 내용
+ * @param leftButtonText - 왼쪽 버튼 텍스트
+ * @param leftButtonText - 오른쪽 버튼 텍스트
+ * @param onClick - 실행할 함수
+ * @returns
+ */
+
+const ModalConfirm = ({
+  content,
+  leftButtonText,
+  rightButtonText,
+  onClick,
+}: ModalConfirm) => {
+  const modalStatus = useContext(ModalContext)
+
+  const handleLeftClick = () => {
+    modalStatus.setIsOpen.call(null, false)
+  }
+
+  const handleRightClick = () => {
+    modalStatus.setIsOpen.call(null, false)
+    onClick()
+  }
+
+  return (
+    <div className={S.container}>
+      <span className={S.content}>{content}</span>
+      <div className={S.button}>
+        <OptionButton
+          size="large"
+          leftColor="white"
+          rightColor="purple"
+          leftText={leftButtonText}
+          rightText={rightButtonText}
+          onLeftClick={handleLeftClick}
+          onRightClick={handleRightClick}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default ModalConfirm

--- a/src/components/dashboard/editor/index.tsx
+++ b/src/components/dashboard/editor/index.tsx
@@ -11,6 +11,8 @@ import S from './DashboardEditor.module.scss'
 import BorderButton from '../../common/button/border'
 import ColorChip from '../../common/chip/color-chip'
 import Input from '../../common/input'
+import Modal from '../../common/modal'
+import ModalConfirm from '../../common/modal/modal-confirm'
 
 interface DashboardEditorProps {
   dashboardId: number
@@ -28,13 +30,21 @@ function DashboardEditor({ dashboardId }: DashboardEditorProps) {
 
   const { dashboardDetail, setDashboardDetail, editSideMenuDashboards } =
     useContext(DashboardsContext)
-
   const initialColor =
     dashboardDetail && typeof dashboardDetail.color === 'string'
       ? dashboardDetail.color
       : ''
 
   const [selectedColor, setSelectedColor] = useState(initialColor)
+
+  const [changedDasgboardValue, setChangedDasgboardValue] =
+    useState<EditDahsboardParamType>()
+
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
+  const handleClick = () => {
+    setIsModalOpen(true)
+  }
 
   const editDashboard = async (data: EditDahsboardParamType) => {
     try {
@@ -54,34 +64,48 @@ function DashboardEditor({ dashboardId }: DashboardEditorProps) {
   }, [initialColor])
 
   return (
-    <form
-      className={S.container}
-      onSubmit={handleSubmit((data) => {
-        const { newDash: title } = data
-        editDashboard({ title: title, color: selectedColor })
-      })}
-    >
-      <div className={S.header}>
-        <span>{dashboardDetail && dashboardDetail.title}</span>
-        <ColorChip
-          selectedColor={selectedColor}
-          setSelectedColor={setSelectedColor}
+    <>
+      {isModalOpen && changedDasgboardValue && (
+        <Modal setIsOpen={setIsModalOpen}>
+          <ModalConfirm
+            content="대시보드를 변경하시겠습니까?"
+            leftButtonText="취소"
+            rightButtonText="변경"
+            onClick={() => editDashboard(changedDasgboardValue)}
+          />
+        </Modal>
+      )}
+
+      <form
+        className={S.container}
+        onSubmit={handleSubmit((data) => {
+          const { newDash: title } = data
+          setChangedDasgboardValue({ title: title, color: selectedColor })
+          handleClick()
+        })}
+      >
+        <div className={S.header}>
+          <span>{dashboardDetail && dashboardDetail.title}</span>
+          <ColorChip
+            selectedColor={selectedColor}
+            setSelectedColor={setSelectedColor}
+          />
+        </div>
+        <div className={S.inputTitle}>대시보드 이름</div>
+        <Input
+          inputType="newDash"
+          placeholder="뉴프로젝트"
+          register={register}
+          error={errors.newDash}
+          size="large"
         />
-      </div>
-      <div className={S.inputTitle}>대시보드 이름</div>
-      <Input
-        inputType="newDash"
-        placeholder="뉴프로젝트"
-        register={register}
-        error={errors.newDash}
-        size="large"
-      />
-      <div className={S.buttonBox}>
-        <BorderButton size="small" color="purple">
-          변경
-        </BorderButton>
-      </div>
-    </form>
+        <div className={S.buttonBox}>
+          <BorderButton size="small" color="purple">
+            변경
+          </BorderButton>
+        </div>
+      </form>
+    </>
   )
 }
 

--- a/src/components/dashboard/header/index.tsx
+++ b/src/components/dashboard/header/index.tsx
@@ -7,13 +7,10 @@ import addBoxIcon from '@/public/icons/add-box-icon.svg'
 import barIcon from '@/public/icons/bar.svg'
 import crownIcon from '@/public/icons/crown-icon.svg'
 import settingIcon from '@/public/icons/setting-icon.svg'
-import tempCircle1 from '@/public/icons/temp-circle-1.svg'
-import tempCircle2 from '@/public/icons/temp-circle-2.svg'
-import tempCircle3 from '@/public/icons/temp-circle-3.svg'
-import tempCircle4 from '@/public/icons/temp-circle-4.svg'
-import tempCircle5 from '@/public/icons/temp-circle-5.svg'
 import { DashboardsContext } from '@/src/context/dashboards'
+import { InviteeEmailContext } from '@/src/context/inviteeEmail'
 import { MembersContext } from '@/src/context/members'
+import { useToast } from '@/src/context/toast'
 import { useUser } from '@/src/context/users'
 import { InviteDashboardParamType } from '@/src/types/mydashboard'
 
@@ -22,14 +19,6 @@ import ManagerProfile from '../../common/manager-profile'
 import Modal from '../../common/modal'
 import ModalDashBoard from '../../common/modal/modal-dashboard'
 import UserDefaultImg from '../../common/user-default-img'
-
-const EMPTY_IMG = [
-  tempCircle1,
-  tempCircle2,
-  tempCircle3,
-  tempCircle4,
-  tempCircle5,
-]
 
 // TODO: 타입좁히기
 // type PathName = '/mydashboard' | '/mypage' | '/dashboard/[id]' /'dashboard/[id]/edit'
@@ -47,14 +36,29 @@ function DashboardHeader({ pathname }: DashboardHeaderProps) {
   const { userData } = useUser()
   const { headerMembers } = useContext(MembersContext)
   const { dashboardDetail } = useContext(DashboardsContext)
+  const { handleCreate } = useContext(InviteeEmailContext)
+  const { addToast } = useToast()
   const visibleMemberNum = 4
 
   const {
     query: { id },
   } = useRouter()
-  const dashboardId = id && +id
+
+  const dashboardId = typeof id !== 'undefined' ? +id : -1
   const router = useRouter()
   const [isModalOpen, setIsModalOpen] = useState(false)
+
+  const InviteDashboard = async (data: InviteDashboardParamType) => {
+    if (dashboardId === -1) return
+    try {
+      await fetchPostInviteDashboard(data, dashboardId)
+      handleCreate()
+      addToast('초대가 완료되었습니다.', 'success')
+    } catch (err) {
+      addToast('유효하지 않은 이메일입니다.', 'error')
+      console.error(err)
+    }
+  }
 
   const BUTTONS = useMemo(
     () => [
@@ -77,15 +81,6 @@ function DashboardHeader({ pathname }: DashboardHeaderProps) {
     ],
     [dashboardId],
   )
-
-  const InviteDashboard = async (data: InviteDashboardParamType) => {
-    try {
-      if (dashboardId) await fetchPostInviteDashboard(data, +dashboardId)
-    } catch (err) {
-      console.error(err)
-    }
-  }
-
   // TODO: 로딩 구현
   if (!userData)
     return (

--- a/src/components/dashboard/invited-list/email/index.tsx
+++ b/src/components/dashboard/invited-list/email/index.tsx
@@ -42,6 +42,7 @@ function InviteListEmail({ dashboardId }: InviteListEmailProps) {
       handleCreate()
       addToast('초대가 완료되었습니다.', 'success')
     } catch (err) {
+      addToast('유효하지 않은 이메일입니다.', 'error')
       console.error(err)
     }
   }


### PR DESCRIPTION
## 🚀 주요 변경 사항

- 대시보드 수정 페이지에서 쓸 확인용 모달 ModalConfirm 생성하였습니다.
- 대시보드 수정 페이지에 적용하였습니다.
- 구성원 삭제 할때 닉네임이 같이 메시지에 보이게끔 적용했습니다.
- 초대하기 취소할때도 이메일이 같이 메시지에 보이게끔 적용했습니다.

## 🖼️ 스크린샷
- 관리자 버튼 막는 거 대신 토스트로 변경
![image](https://github.com/WhatToDo6/WhatToDo/assets/107683008/3e3d6ae6-b9fe-44fe-a054-be92fd33b178)
- 구성원 삭제
![image](https://github.com/WhatToDo6/WhatToDo/assets/107683008/29032892-c982-4c2e-8b3f-b86910f9567c)
- 초대하기 취소
![image](https://github.com/WhatToDo6/WhatToDo/assets/107683008/6ebe866c-30f8-4a59-b5d9-57cc7f310edb)


## 📝 기타 논의 사항
