### PR TITLE
비밀번호 유효성 검증 로직 강화

### DIFF
--- a/src/components/common/input/new-password/index.tsx
+++ b/src/components/common/input/new-password/index.tsx
@@ -32,7 +32,8 @@ const InputNewPassword = ({
           required: '새 비밀번호를 입력해주세요.',
           validate: {
             validPassword: (value) =>
-              validatePassword(value) || '새 비밀번호는 8자 이상 입력해주세요.',
+              validatePassword(value) ||
+              '영문, 숫자를 조합해 8자 이상 입력해 주세요',
             notSameAsOld: (value) =>
               value !== currentPassword || '기존 비밀번호와 동일합니다.',
           },

--- a/src/components/common/input/password/index.tsx
+++ b/src/components/common/input/password/index.tsx
@@ -30,7 +30,8 @@ const InputPassword = ({
         {...register('password', {
           required: '비밀번호를 입력해주세요.',
           validate: (value) =>
-            validatePassword(value) || '8자 이상 입력해 주세요.',
+            validatePassword(value) ||
+            '영문, 숫자를 조합해 8자 이상 입력해 주세요',
         })}
       />
       <div className={`${S.eyeContainer} ${S[`${size}Eye`]}`}>

--- a/src/components/login-signup/form/signup/index.tsx
+++ b/src/components/login-signup/form/signup/index.tsx
@@ -84,7 +84,7 @@ const SignUpForm = () => {
         <label className={S.label}>비밀번호</label>
         <Input
           inputType="password"
-          placeholder="8자 이상 입력해 주세요"
+          placeholder="영문, 숫자를 조합해 8자 이상 입력해 주세요"
           error={errors.password}
           register={register}
         />

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,5 +1,5 @@
 export const EMAIL_REGEX = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/
-export const PASSWORD_REGEX = /^(.{1,7})$/
+export const PASSWORD_REGEX = /^(.{1,7}|[a-zA-Z]+|\d+)$/
 
 /**
  * 이메일 주소의 유효성을 검사


### PR DESCRIPTION
## 🚀 주요 변경 사항

### 1. 비밀번호 유효성 검증 로직 강화 #160 

- 기존 : 8자 이상
- 변경 후 : 영문, 숫자를 조합해 8자 이상 

### 2. 로직에 맞춰 비밀번호 관련 문구 수정

> 영문, 숫자를 조합해 8자 이상 입력해 주세요

- 회원가입 페이지 비밀번호 입력란 placeholder
- 회원가입 및 비밀번호 수정 시 에러 문구 수정

## 🖼️ 스크린샷

<img width="651" alt="image" src="https://github.com/WhatToDo6/WhatToDo/assets/77491430/b0edc688-b0d0-4e9c-b558-aaf8804bc13b">


## 📝 기타 논의 사항
