### PR TITLE
Comment edit input css추가, ModalTask, Commnet, TaskCard css 수정

### DIFF
--- a/src/components/common/button/border/BorderButton.module.scss
+++ b/src/components/common/button/border/BorderButton.module.scss
@@ -9,6 +9,7 @@
   width: 8.4rem;
   padding: 0.7rem 2.9rem;
   &:disabled {
+    color: $color-gray-200;
     background-color: $color-gray-400;
     cursor: not-allowed;
   }

--- a/src/components/common/modal/modal-task/ModalTask.module.scss
+++ b/src/components/common/modal/modal-task/ModalTask.module.scss
@@ -241,7 +241,7 @@
 }
 
 .spinnerWrapper {
-  width: 50%;
+  width: 60%;
   display: flex;
   justify-content: center;
 

--- a/src/components/common/modal/modal-task/ModalTask.module.scss
+++ b/src/components/common/modal/modal-task/ModalTask.module.scss
@@ -11,7 +11,6 @@
   border-radius: 0.8rem;
   background-color: $color-white;
   overflow-y: scroll;
-  -ms-overflow-style: none;
 
   @include tablet {
     width: 68rem;
@@ -20,10 +19,6 @@
   @include mobile {
     width: 32.7rem;
     padding: 4rem 2rem 2.8rem;
-  }
-
-  &::-webkit-scrollbar {
-    display: none;
   }
 }
 
@@ -253,4 +248,22 @@
   @include mobile {
     width: 100%;
   }
+}
+
+.container::-webkit-scrollbar {
+  width: 0.8rem;
+}
+
+.container::-webkit-scrollbar-track {
+  background: $color-white;
+  border-radius: 0.8rem;
+}
+
+.container::-webkit-scrollbar-thumb {
+  background: $color-gray-200;
+  border-radius: 0.8rem;
+}
+
+.container::-webkit-scrollbar-thumb:hover {
+  background: $color-gray-300;
 }

--- a/src/components/common/modal/modal-task/ModalTask.module.scss
+++ b/src/components/common/modal/modal-task/ModalTask.module.scss
@@ -22,8 +22,21 @@
   }
 }
 
+.titleContainer {
+  width: 45rem;
+
+  @include tablet {
+    width: 42rem;
+  }
+
+  @include mobile {
+    width: 21rem;
+  }
+}
+
 .title {
   color: $color-black-200;
+  word-wrap: break-word;
   @include font-style(2.4rem, 700, normal);
 
   @include mobile {

--- a/src/components/common/modal/modal-task/ModalTask.module.scss
+++ b/src/components/common/modal/modal-task/ModalTask.module.scss
@@ -147,10 +147,19 @@
 }
 
 .text {
+  width: 45rem;
+  height: 7.2rem;
   color: $color-black-400;
+  word-wrap: break-word;
   @include font-style(1.4rem, 400, 2.4rem);
 
+  @include tablet {
+    width: 42rem;
+  }
+
   @include mobile {
+    width: 28.7rem;
+    height: 9rem;
     @include font-style(1.2rem, 400, 2.2rem);
   }
 }
@@ -195,6 +204,7 @@
 .assignee {
   display: flex;
   flex-direction: column;
+  justify-content: center;
   gap: 0.6rem;
 
   @include mobile {
@@ -205,6 +215,7 @@
 .dueDate {
   display: flex;
   flex-direction: column;
+  justify-content: center;
   gap: 0.6rem;
 
   @include mobile {

--- a/src/components/common/modal/modal-task/comment/Comment.module.scss
+++ b/src/components/common/modal/modal-task/comment/Comment.module.scss
@@ -1,11 +1,17 @@
 @import '@/src/styles/global.scss';
 
 .container {
+  width: 40rem;
   display: flex;
   gap: 1rem;
   align-items: center;
 
+  @include tablet {
+    width: 37rem;
+  }
+
   @include mobile {
+    width: 24rem;
     gap: 0.8rem;
   }
 }
@@ -20,6 +26,7 @@
 }
 
 .comment {
+  width: 100%;
   padding-top: 0.8rem;
 
   @include mobile {
@@ -56,7 +63,9 @@
 }
 
 .description {
+  width: 100%;
   margin-bottom: 1.2rem;
+  word-wrap: break-word;
   color: $color-black-200;
   @include font-style(1.4rem, 400, normal);
 
@@ -83,5 +92,25 @@
 
   @include mobile {
     @include font-style(1rem, 400, normal);
+  }
+}
+
+.editTextarea {
+  box-sizing: border-box;
+  display: block;
+  width: 100%;
+  border-radius: 0.6rem;
+  padding: 1.6rem;
+  margin-bottom: 1rem;
+  border: 0.1rem solid $color-gray-300;
+  resize: none;
+
+  &:focus {
+    outline: none;
+    border-color: $color-violet-200;
+  }
+
+  @include mobile {
+    padding: 1.2rem;
   }
 }

--- a/src/components/common/modal/modal-task/comment/index.tsx
+++ b/src/components/common/modal/modal-task/comment/index.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 
 import { putComments } from '@/pages/api/comments'
 import { CommentsType } from '@/src/types/dashboard'
+import { formatDate } from '@/src/utils/formatDate'
 
 import S from './Comment.module.scss'
 import ManagerProfile from '../../../manager-profile'
@@ -16,6 +17,7 @@ const Comment = ({
   const [isEditing, setIsEditing] = useState(false)
   const [editContent, setEditContent] = useState(initialContent)
   const [content, setContent] = useState(initialContent)
+  const formatCreatedAt = formatDate(String(createdAt))
 
   const handleEdit = () => {
     setIsEditing(true)
@@ -56,7 +58,7 @@ const Comment = ({
       <div className={S.comment}>
         <div className={S.title}>
           <span className={S.people}>{author.nickname}</span>
-          <p className={S.createdAt}>{createdAt}</p>
+          <p className={S.createdAt}>{formatCreatedAt}</p>
         </div>
         {isEditing ? (
           <textarea

--- a/src/components/common/modal/modal-task/index.tsx
+++ b/src/components/common/modal/modal-task/index.tsx
@@ -11,6 +11,7 @@ import { EMPTY_DUEDATE } from '@/src/constants/date'
 import useIntersectionObserver from '@/src/hooks/useInterSectionObserver'
 import { CommentsType, TaskCardDataType } from '@/src/types/dashboard'
 import { ModalTaskProps } from '@/src/types/modal'
+import { formatDate } from '@/src/utils/formatDate'
 
 import Comment from './comment'
 import CommentForm from './comment-form/index'

--- a/src/components/dashboard/column/task-card/TaskCard.module.scss
+++ b/src/components/dashboard/column/task-card/TaskCard.module.scss
@@ -36,6 +36,10 @@
   }
 }
 
+.cardTitle {
+  word-wrap: break-word;
+}
+
 .imageWrapper {
   width: 100%;
   display: flex;

--- a/src/components/dashboard/column/task-card/TaskCard.module.scss
+++ b/src/components/dashboard/column/task-card/TaskCard.module.scss
@@ -57,6 +57,10 @@
   }
 }
 
+.cardImage {
+  border-radius: 0.4rem;
+}
+
 .content {
   display: flex;
   flex-direction: column;

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -130,3 +130,9 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
 }
+
+body::-webkit-scrollbar {
+  display: none;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}


### PR DESCRIPTION
## 🚀 주요 변경 사항

### Comment를 수정하는 input css를 추가했습니다.
- 입력 input과 동일한 디자인을 적용했습니다.

### ModalTask, Comment, TaskCard 자잘한 수정
- 제목이나 내용 텍스트가 길어지면 컨텐츠 밖으로 삐져나가는 현상을 막기 위해 개행처리해두었습니다.
- 댓글 날짜를 formatDate 함수로 처리하여 시간까지만 나타나게 하였습니다.
- ModalTask의 이미지에 border-radius 추가했습니다.

### ModalTask 스크롤바 수정
- 원석님이 side-menu에 적용한 스크롤바 디자인을 가져다 썼습니다.

## 🖼️ 스크린샷

![image](https://github.com/WhatToDo6/WhatToDo/assets/108844881/6f57e3ea-568c-4e10-8a2f-7ad2b1a39b52)

![image](https://github.com/WhatToDo6/WhatToDo/assets/108844881/5e311c27-8643-478e-af0c-5e46f9c97c63)

![image](https://github.com/WhatToDo6/WhatToDo/assets/108844881/6fd0c75e-479f-41a0-825e-a251099bcd45)

![image](https://github.com/WhatToDo6/WhatToDo/assets/108844881/6626cd91-3d12-4183-a273-ee7f9e84a6dc)


## 📝 기타 논의 사항
