### PR TITLE
대시보드 헤더 화면 고정

### DIFF
--- a/src/components/common/layout/Layout.module.scss
+++ b/src/components/common/layout/Layout.module.scss
@@ -44,7 +44,7 @@
 }
 
 .header {
-  position: absolute;
+  position: fixed;
   right: 0;
   width: calc(100% - 30rem);
   z-index: 2;


### PR DESCRIPTION
## 🚀 주요 변경 사항

- 대시보드 헤더를 화면에서 고정되도록 수정하였습니다!

## 🖼️ 스크린샷

https://github.com/WhatToDo6/WhatToDo/assets/129318957/5b1678ed-dd7a-4c1c-a30a-66bba5d48230


## 📝 기타 논의 사항
