### PR TITLE
버그 수정

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,7 +11,7 @@ export default function App({ Component, pageProps }: AppProps) {
         <title>Taskify</title>
         <link
           rel="icon"
-          href="https://raw.githubusercontent.com/WhatToDo6/WhatToDo/027f5302001614a333b41894bd24b212cc73eb75/public/favicon.ico"
+          href="https://raw.githubusercontent.com/WhatToDo6/WhatToDo/develop/public/favicon.ico"
         />
       </Head>
       <Component {...pageProps} />

--- a/pages/dashboards/[id]/index.tsx
+++ b/pages/dashboards/[id]/index.tsx
@@ -39,6 +39,12 @@ const DashboardIdPage = ({ id }: { id: number }) => {
   }
 
   const handleAPI = async (data: ColumnTitleType) => {
+    for (let i in columns) {
+      if (columns[i].title === data.newColumn) {
+        alert('이미 존재하는 컬럼명입니다.')
+        return
+      }
+    }
     try {
       const requestData = {
         title: data.newColumn,

--- a/src/components/common/modal/modal-dashboard/index.tsx
+++ b/src/components/common/modal/modal-dashboard/index.tsx
@@ -46,7 +46,7 @@ const ModalDashBoard = ({
     handleSubmit,
     formState: { errors },
     watch,
-  } = useForm<InputFormValues>({ mode: 'onBlur' })
+  } = useForm<InputFormValues>({ mode: 'onChange' })
 
   const ButtonDisabledCond =
     watch('email') || watch('newColumn') || watch('columnName')

--- a/src/components/common/modal/modal-edittodo/index.tsx
+++ b/src/components/common/modal/modal-edittodo/index.tsx
@@ -36,7 +36,7 @@ const ModalEdittodo = ({ cardData, setCardData }: ModalEdittodoProps) => {
     control,
     setValue,
     watch,
-  } = useForm<InputFormValues>({ mode: 'onBlur' })
+  } = useForm<InputFormValues>({ mode: 'onChange' })
 
   useEffect(() => {
     fetchGetUser().then((data) => setUserId(data.id))

--- a/src/components/common/modal/modal-newdash/index.tsx
+++ b/src/components/common/modal/modal-newdash/index.tsx
@@ -28,7 +28,7 @@ const ModalNewDash = ({ moveTo, onSubmit }: ModalNewDashProps) => {
     handleSubmit,
     formState: { errors },
     watch,
-  } = useForm<InputFormValues>({ mode: 'onBlur' })
+  } = useForm<InputFormValues>({ mode: 'onChange' })
 
   const handleLeftClick = () => {
     modalStatus.setIsOpen.call(null, false)

--- a/src/components/common/modal/modal-todo/index.tsx
+++ b/src/components/common/modal/modal-todo/index.tsx
@@ -30,7 +30,7 @@ const ModalTodo = ({
     formState: { errors },
     control,
     setValue,
-  } = useForm<InputFormValues>({ mode: 'onBlur' })
+  } = useForm<InputFormValues>({ mode: 'onChange' })
 
   useEffect(() => {
     fetchGetUser().then((data) => setUserId(data.id))

--- a/src/components/dashboard/editor/index.tsx
+++ b/src/components/dashboard/editor/index.tsx
@@ -25,7 +25,7 @@ function DashboardEditor({ dashboardId }: DashboardEditorProps) {
     handleSubmit,
     formState: { errors },
     reset,
-  } = useForm<InputFormValues>({ mode: 'onBlur' })
+  } = useForm<InputFormValues>({ mode: 'onChange' })
 
   const { addToast } = useToast()
   const changeableVal = useMobileSizeChange<boolean>(false, true)

--- a/src/components/login-signup/form/login/index.tsx
+++ b/src/components/login-signup/form/login/index.tsx
@@ -21,7 +21,7 @@ const LogInForm = () => {
     handleSubmit,
     formState: { errors },
     watch,
-  } = useForm<InputFormValues>({ mode: 'onBlur' })
+  } = useForm<InputFormValues>({ mode: 'onChange' })
 
   const onSubmit: SubmitHandler<InputFormValues> = (data) => {
     if (data.email === '' || data.password === '') return

--- a/src/components/login-signup/form/signup/index.tsx
+++ b/src/components/login-signup/form/signup/index.tsx
@@ -24,7 +24,7 @@ const SignUpForm = () => {
     handleSubmit,
     formState: { errors },
     watch,
-  } = useForm<InputFormValues>({ mode: 'onBlur' })
+  } = useForm<InputFormValues>({ mode: 'onChange' })
 
   const onSubmit: SubmitHandler<InputFormValues> = (data) => {
     if (!isChecked || Object.keys(errors).length > 0) return
@@ -49,7 +49,7 @@ const SignUpForm = () => {
   return (
     <>
       {isSuccessModalOpen && (
-        <Modal setIsOpen={setIsSuccessModalOpen}>
+        <Modal isOpen={isSuccessModalOpen} setIsOpen={setIsSuccessModalOpen}>
           <ModalAlert
             content="가입이 완료되었습니다!"
             buttonText="확인"
@@ -58,7 +58,7 @@ const SignUpForm = () => {
         </Modal>
       )}
       {isErrorModalOpen && (
-        <Modal setIsOpen={setIsErrorModalOpen}>
+        <Modal isOpen={isErrorModalOpen} setIsOpen={setIsErrorModalOpen}>
           <ModalAlert
             content="이미 사용 중인 이메일입니다."
             buttonText="확인"

--- a/src/components/mypage/password/index.tsx
+++ b/src/components/mypage/password/index.tsx
@@ -21,7 +21,7 @@ const Password = () => {
     formState: { errors },
     reset,
     watch,
-  } = useForm<InputFormValues>({ mode: 'onBlur' })
+  } = useForm<InputFormValues>({ mode: 'onChange' })
 
   const onSubmit: SubmitHandler<InputFormValues> = (data) => {
     const accessToken = localStorage.getItem('accessToken')

--- a/src/components/mypage/profile-form/index.tsx
+++ b/src/components/mypage/profile-form/index.tsx
@@ -31,7 +31,7 @@ const ProfileForm = () => {
     handleSubmit,
     reset,
     formState: { errors },
-  } = useForm<InputFormValues>({ mode: 'onBlur' })
+  } = useForm<InputFormValues>({ mode: 'onChange' })
 
   const onSubmit: SubmitHandler<InputFormValues> = (data) => {
     const accessToken = localStorage.getItem('accessToken')

--- a/src/context/users.tsx
+++ b/src/context/users.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router'
 import { createContext, useContext, useState, useEffect } from 'react'
 
 import { fetchGetUser } from '@/pages/api/users'
@@ -18,6 +19,7 @@ export const useUser = () => useContext(UserContext)
 
 export const UserProvider = ({ children }: ChildrenProps) => {
   const [userData, setUserData] = useState<UserType | null>(null)
+  const router = useRouter()
 
   useEffect(() => {
     const fetchUserData = async () => {
@@ -26,6 +28,7 @@ export const UserProvider = ({ children }: ChildrenProps) => {
         setUserData(user)
       } catch (error) {
         console.error('유저의 정보를 불러오지 못했습니다.', error)
+        router.replace('/')
       }
     }
 


### PR DESCRIPTION
## 🚀 주요 변경 사항

### 1. 비로그인 유저 접근 방지 #170

- 대상 : 마이페이지, 나의 대시보드, 대시보드
- 방법 : userContext에서 401 에러가 날 경우, 랜딩 페이지로 이동시킴. 이 때 router.push 대신 router.replace를 사용해서 페이지를 교체함으로써 뒤로 가기 버튼을 눌러도 접근하지 못하게 함

### 2. 중복 컬럼명으로 컬럼 추가 방지 #183 

### 3. Input 컴포넌트에서 onChange 이벤트에 유효성 검사 실행 #180 

- react-hook-form의 모드를 onBlur에서 onChange로 변경


