### PR TITLE
대시보드 삭제 후 /mydashboard 로 이동하게 구현

### DIFF
--- a/pages/mydashboard/MyDashboard.module.scss
+++ b/pages/mydashboard/MyDashboard.module.scss
@@ -7,7 +7,6 @@
   padding-top: 4rem;
   margin-left: 4rem;
 
-
   .invitedDashboard {
     margin-top: 3rem;
     margin-bottom: 3rem;
@@ -18,7 +17,7 @@
   }
 
   @include tablet {
-    width: 100%;
+    width: 50.4rem;
   }
 
   @include mobile {

--- a/src/context/dashboards.tsx
+++ b/src/context/dashboards.tsx
@@ -87,6 +87,7 @@ function DashboardsProvider({ children }: ChildrenProps) {
       const dashboard = await fetchGetDashboardDetail(dashboardId)
       setDashboardDetail(dashboard)
     } catch (err) {
+      router.push('/mydashboard')
       console.error(err)
     }
   }


### PR DESCRIPTION
## 🚀 주요 변경 사항

- 대시보드 삭제 후 뒤로 가기나 url 접근시 /mydashboard 로 이동하게 구현 (router.replace로 구현하고 싶었지만 replace로 할 경우 데이터가 업데이트가 안되는 현상이 있어서 추후에 수정하겠습니다.)
- 반응형 합치면서 css 적용이 안된부분이 있어서 수정 했습니다.
 
## 🖼️ 스크린샷

## 📝 기타 논의 사항
